### PR TITLE
feat: add charmlibs package and publication actions

### DIFF
--- a/.github/workflows/publish-charmlibs-package.yaml
+++ b/.github/workflows/publish-charmlibs-package.yaml
@@ -1,0 +1,31 @@
+name: Publish 'charmlibs' package
+on:
+  push:
+    tags:
+      - 'charmlibs-v*.*.*'
+
+jobs:
+  tests:
+    uses: ./.github/workflows/tests.yaml
+  build-n-publish:
+    name: Build and Publish 'charmlibs' to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    needs: [tests]
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Build
+        run: uv build
+        working-directory: ./_charmlibs
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2.2.3
+        with:
+          subject-path: '_charmlibs/dist/*'
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: ./_charmlibs/dist/

--- a/.github/workflows/test-publish-charmlibs-package.yaml
+++ b/.github/workflows/test-publish-charmlibs-package.yaml
@@ -1,0 +1,30 @@
+name: Test Publish 'charmlibs' package
+on:
+  workflow_dispatch:
+
+jobs:
+  tests:
+    uses: ./.github/workflows/tests.yaml
+  build-n-publish:
+    name: Build and Publish 'charmlibs' to Test PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    needs: [tests]
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Build
+        run: uv build
+        working-directory: ./_charmlibs
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2.2.3
+        with:
+          subject-path: '_charmlibs/dist/*'
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: ./_charmlibs/dist/
+          repository-url: https://test.pypi.org/legacy/

--- a/_charmlibs/README.md
+++ b/_charmlibs/README.md
@@ -1,0 +1,5 @@
+# charmlibs
+
+This package should not be installed - it exists solely to reserve the `charmlibs` namespace.
+
+See the [charmlibs documentation site](https://canonical-charmlibs.readthedocs-hosted.com/) for more information.

--- a/_charmlibs/pyproject.toml
+++ b/_charmlibs/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "charmlibs"
+description = "The charmlibs namespace. This package should not be installed."
+readme = "README.md"
+requires-python = ">=3.8"
+authors = [
+    {name="The Charm Tech team at Canonical Ltd."},
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: Apache Software License",
+    "Intended Audience :: Developers",
+    "Operating System :: POSIX :: Linux",
+    "Development Status :: 2 - Pre-Alpha",
+]
+dynamic = ["version"]
+
+[project.urls]
+"Repository" = "https://github.com/canonical/charmtech-charmlibs"
+"Issues" = "https://github.com/canonical/charmtech-charmlibs/issues"
+
+[build-system]
+requires = [
+    "setuptools>=60",
+]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.dynamic]
+version = {attr = "charmlibs.__version__"}

--- a/_charmlibs/src/charmlibs/__init__.py
+++ b/_charmlibs/src/charmlibs/__init__.py
@@ -5,6 +5,6 @@ For more information, see the PyPI page at https://pypi.org/project/charmlibs
 
 import warnings
 
-__version__ = "0.0.0a0"
+__version__ = '0.0.0a0'
 
-warnings.warn("This package should not be installed.", stacklevel=1)
+warnings.warn('This package should not be installed.', stacklevel=1)

--- a/_charmlibs/src/charmlibs/__init__.py
+++ b/_charmlibs/src/charmlibs/__init__.py
@@ -1,0 +1,10 @@
+"""This package should not be installed - it exists solely to reserve the PyPI charmlibs namespace.
+
+For more information, see the PyPI page at https://pypi.org/project/charmlibs
+"""
+
+import warnings
+
+__version__ = "0.0.0a0"
+
+warnings.warn("This package should not be installed.", stacklevel=1)

--- a/_charmlibs/src/charmlibs/__init__.py
+++ b/_charmlibs/src/charmlibs/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """This package should not be installed - it exists solely to reserve the PyPI charmlibs namespace.
 
 For more information, see the PyPI page at https://pypi.org/project/charmlibs


### PR DESCRIPTION
This PR adds the `charmlibs` package to this repository. This is supposed to be a minimal package that just claims the name on PyPI. It shouldn't be installed, so it emits a warning at import time.

This PR also adds the workflows to publish the package to PyPI and test PyPI. Due to the monorepo structure, PyPI publication is triggered by tags being pushed, while publication to test PyPI is triggered manually.