### PR TITLE
ci: add missing checkout step to charmlibs publish workflows

### DIFF
--- a/.github/workflows/publish-charmlibs-package.yaml
+++ b/.github/workflows/publish-charmlibs-package.yaml
@@ -16,6 +16,7 @@ jobs:
       contents: read
     needs: [tests]
     steps:
+      - uses: actions/checkout@v4
       - name: Install uv
         uses: astral-sh/setup-uv@v5
       - name: Build

--- a/.github/workflows/test-publish-charmlibs-package.yaml
+++ b/.github/workflows/test-publish-charmlibs-package.yaml
@@ -14,6 +14,7 @@ jobs:
       contents: read
     needs: [tests]
     steps:
+      - uses: actions/checkout@v4
       - name: Install uv
         uses: astral-sh/setup-uv@v5
       - name: Build


### PR DESCRIPTION
This PR adds the erroneously omitted 'checkout' step to the charmlibs publication workflows.