### PR TITLE
docs: add Python packages how-to

### DIFF
--- a/_docs/conf.py
+++ b/_docs/conf.py
@@ -266,7 +266,7 @@ extensions = [
 intersphinx_mapping = {
     'ops': ('https://ops.readthedocs.io/en/latest', None),
     'python': ('https://docs.python.org/3', None),
-    'juju': ('https://canonical-juju.readthedocs-hosted.com/en/latest', None),
+    'juju': ('https://documentation.ubuntu.com/juju/latest', None),
     'charmcraft': ('https://canonical-charmcraft.readthedocs-hosted.com/en/latest', None),
 }
 

--- a/_docs/how-to/index.md
+++ b/_docs/how-to/index.md
@@ -1,0 +1,7 @@
+# How To
+
+```{toctree}
+:maxdepth: 1
+
+Distribute charm libraries <python-packages>
+```

--- a/_docs/how-to/index.md
+++ b/_docs/how-to/index.md
@@ -3,5 +3,5 @@
 ```{toctree}
 :maxdepth: 1
 
-Distribute charm libraries <python-packages>
+Distribute charm libraries <python-package>
 ```

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -27,11 +27,9 @@ However, the reasons listed above should take priority even in this case.
 ## Naming and namespacing your Python package
 
 For charm libraries intended for public use and distributed as Python packages,
-we recommend using the `charmlibs` namespace,
-particularly if your library is intended for other charmers to use.
+we recommend using the `charmlibs` namespace.
 The package name should be `charmlibs-$libname`,
-imported as `from charmlibs import $libname`
-(or `import charmlibs.$libname as $libname` if you're stuck on an older `pyright` version that complains about the other form).
+imported as `from charmlibs import $libname`.
 
 The package should be a [namespace package](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/)
 using the `charmlibs` namespace.

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -71,10 +71,14 @@ and to make charm library documentation easier to find.
 (python-package-distribution)=
 ## How to distribute your Python package
 
-Distributing your package on PyPI has the most benefits.
-However, you may find it useful to begin by distributing your package via a git url during development and internal use.
+Distributing your package on PyPI allows your users to use dependency ranges,
+improves discoverability,
+and makes it easier for users to install your library.
+However, it requires some additional work to publish,
+and is most appropriate if your library is intended for public use.
+You may find it useful to begin by distributing your package via a git url during development and team internal use.
 Using a git dependency
-or skipping distribution in favour of packing the local package
+or skipping distribution in favour of packing the local files with your charm
 may be appropriate if your library is purely for your own charms,
 and is not intended for external users.
 

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -160,13 +160,8 @@ Then you can specify the dependency in your requirements like this:
 ops @ git+https://github.com/canonical/operator@main
 ```
 
-If you don’t specify a branch or tag, it will default to `main`.
-This is probably sufficient for early prototyping and internal use.
-If you push git tags for releases or do releases on GitHub, you could point to the exact release tag, e.g. `@v2.18.1`.
-Another approach which could be useful for prototyping would be to pin on a branch,
-e.g. `stable/candidate/beta/edge`, `dev/main`, `v0/v1/v2`, etc.
-These approaches may be useful as your library stabilises internally, but if you find yourself thinking about a scheme like this,
-it’s probably a sign to switch to PyPI and use semantic versioning.
+You can specify any branch, tag, or commit after the `@`.
+If you leave it off, it will default to `@main`.
 
 If your package is in a subdirectory of your repository
 (for example if you use a monorepo,

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -1,7 +1,8 @@
 (how-to-python-package)=
 # How to distribute charm libraries
 
-This guide details when and how you should create your charm libraries as Python packages, instead of {doc}`Charmcraft-style charm libs <charmcraft:reference/commands/fetch-libs>`.
+This guide details when and how you should create your charm libraries as Python packages,
+instead of {doc}`Charmcraft-style charm libs <charmcraft:reference/commands/fetch-libs>`.
 
 
 (when-to-python-package)=

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -112,7 +112,7 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
 ```
 
-Make sure that your repository only allows trusted contributors write access.
+Make sure that your repository only allows write access from trusted contributors.
 The team manager and another truster team member should be the package owners on PyPI,
 using their Canonical email addresses.
 Make sure to also claim your package on [Test PyPI](https://test.pypi.org/),
@@ -122,7 +122,7 @@ All team members can be owners on Test PyPI.
 A major benefit of publishing on PyPI is that users of your library can specify version ranges in their dependencies.
 Therefore, if you’re going to publish on PyPI, we highly recommend that you use semantic versioning for your library.
 
-A non-dev/alpha/beta/etc qualified 1.x release to PyPI signifies that your library is ready for public consumption.
+A 1.x release to PyPI that isn't qualified with dev/alpha/beta/etc signifies that your library is ready for public consumption.
 You should also communicate this through the ["Development Status" Trove classifier](https://pypi.org/classifiers/) in your `pyproject.toml`.
 
 
@@ -134,7 +134,7 @@ This is good for prototyping, or when first transitioning from a charmcraft-styl
 and may be a good fit for libraries that are intended for team-internal use.
 If your library is intended for external users, consider whether PyPI would be a better choice.
 
-You’ll need to include `git` in your charm’s build dependencies to use a GitHub-hosted library in your charm:
+You’ll need to include `git` in your charm’s build dependencies:
 
 ```yaml
 parts:
@@ -142,7 +142,7 @@ parts:
     build-packages: [git]
 ```
 
-Then you can specify the dependency in your requirements like this:
+Then you can specify the dependency in your requirements:
 
 ```
 charmlibs-pathops @ git+https://github.com/canonical/charmtech-charmlibs@main#subdirectory=pathops
@@ -162,14 +162,13 @@ you'll need to specify the subdirectory.
 If your library has a dedicated repository,
 leave off the subdirectory and it will default to the repository root.
 
-In `pyproject.toml`, quote the entire string above in your dependencies list,
-or use `uv add git+...` to have `uv` add `charmlibs-pathops` to your dependencies list,
-and the git referece to `tool.uv.sources`.
-For `poetry` see [here](https://python-poetry.org/docs/dependency-specification/#git-dependencies).
+In `pyproject.toml`, quote the entire string starting `charmlibs-pathops @ git+...` in your dependencies list.
+Alternatively, use `uv add git+...` to have `uv` add `charmlibs-pathops` to your dependencies list and the git reference to `tool.uv.sources`.
+For `poetry` see [the `poetry` docs](https://python-poetry.org/docs/dependency-specification/#git-dependencies).
 
 
 (python-package-distribution-local)=
-### Local Files
+### Local files
 
 If you're developing a Python package in the same repository as your charm(s),
 it may be simplest to skip distribution and use the local files when packing the charm.
@@ -208,6 +207,7 @@ uv pip install -e ./$charm -e ./$package
 ```
 Using editable installs ensures that the virtual environment reflects all changes made to either `$charm` or `$package`.
 You can then point your editor to the python interpreter in `.venv`, or [activate it manually](https://docs.python.org/3/library/venv.html#how-venvs-work).
+
 To create a virtual environment with a specific python version, use the `--python` flag or define it in a `$repo` level `pyproject.toml`.
 If you take this approach, a `$repo` level `pyproject.toml` is a good place to put your common dev dependencies like `ruff` and `codespell`.
 You can remove the created `.venv` directory to start afresh.
@@ -229,8 +229,8 @@ The approach should be the same if you have multiple charms, (for example `$char
 Your library is not required to depend on `ops`.
 If you do require `ops` as a dependency, specify `ops>=2.X,<3`,
 where 2.X is the lowest `ops` version that you support,
-and 3 is the next major version of `ops`,
-protecting your library from breaking changes.
+and 3 is the next major version of `ops`.
+This protects your library from breaking changes.
 When creating a new library, it’s fine to declare the latest `ops` release as the minimum supported version,
 as charms are encouraged to always use the latest version of `ops`.
 

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -7,23 +7,21 @@ This guide details when and how you should create your charm libraries as Python
 (when-to-python-package)=
 ## When to use a Python package
 
-If your library relies on any dependencies outside the Python standard library and the `ops` package, you should definitely use a Python package.
+You should use a Python package for your charm library if:
 
-If a charm library seems like it will be difficult to manage as a single file, this is another strong sign that it should be a Python package.
+- The library relies on any dependencies other than `ops` and the Python standard library.
 
-For any new libraries that are not logically associated with a single charm,
-including those that are used by both the charmed machine and Kubernetes versions of a piece of software,
-consider if using a Python package will make your life easier.
-This is especially likely to be the case if you are sharing multiple modules between machine and Kubernetes versions of a charm,
-where the individual modules would not obviously be separate Python packages
--- in this case a single Python package will be easier to manage than multiple (perhaps interdependent) charmcraft libs.
+- The library will be difficult to manage as a single file.
 
-The main case where charmcraft libs are likely to be a good alternative to a Python package is for relations.
-In this case, the library is associated with a specific charm,
-it is likely to be simple enough for a single file (as a lot of logic likely lives in the related charms),
+- The library isn't logically associated with a single charm.
+
+- You need to share modules between the machine and Kubernetes versions of a charm.
+
+For a relation library,
+it may still be worthwhile to use a charmcraft lib,
+since the library may be associated with a single charm,
 and there is existing infrastructure and documentation supporting this pattern.
-However, if the relation library relies on any additional dependencies,
-it would probably still be better to make it a Python package.
+However, the reasons listed above should take priority even in this case.
 
 (python-package-name)=
 ## Naming and namespacing your Python package

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -24,12 +24,12 @@ In this case, the library is associated with a specific charm,
 it is likely to be simple enough for a single file (as a lot of logic likely lives in the related charms),
 and there is existing infrastructure and documentation supporting this pattern.
 However, if the relation library relies on any additional dependencies,
-it would still be better to make it a Python package.
+it would probably still be better to make it a Python package.
 
 (python-package-name)=
 ## Naming and namespacing your Python package
 
-For charm libraries distributed as Python packages,
+For charm libraries intended for public use and distributed as Python packages,
 we recommend using the `charmlibs` namespace,
 particularly if your library is intended for other charmers to use.
 The package name should be `charmlibs-$libname`,
@@ -41,13 +41,14 @@ using the `charmlibs` namespace.
 All this means is that your actual package is nested under an empty directory named `charmlibs`.
 Your file structure would look like `src/charmlibs/$libname/__init__.py`.
 There is no need to install the actual package named `charmlibs`.
-This exists on PyPI solely to reserve the package name as a namespace for charm libraries,
+It exists on PyPI solely to reserve the package name as a namespace for charm libraries,
 and to aid charm library discoverability.
 
 If you have a dedicated repository for the charmlib, we recommend naming it `charmlibs-$libname` as well.
 For repositories containing several libraries, consider `$teamname-charmlibs`,
-with the individual packages should still follow the naming and namespace recommendations.
-These recommendations do not apply to other repository organisation schemes.
+with the individual packages following the naming and namespace recommendations.
+These naming  recommendations do not apply to other repository organisation schemes,
+but we still recomend the `charmlibs` namespace if your library is intended for public use.
 
 We don’t recommend using the `ops` or `charm` namespace for your charm libraries distributed as Python packages.
 It will be easier for charmers to follow your code if the `ops` namespace is reserved for the `ops` package.

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -27,32 +27,46 @@ However, the reasons listed above should take priority even in this case.
 ## Naming and namespacing your Python package
 
 For charm libraries intended for public use and distributed as Python packages,
-we recommend using the `charmlibs` namespace.
-The package name should be `charmlibs-$libname`,
+the library should be a [namespace package](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/)
+using the `charmlibs` namespace.
+The distribution package name should be `charmlibs-$libname`,
 imported as `from charmlibs import $libname`.
 
-The package should be a [namespace package](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/)
-using the `charmlibs` namespace.
-All this means is that your actual package is nested under an empty directory named `charmlibs`.
-Your file structure would look like `src/charmlibs/$libname/__init__.py`.
-There is no need to install the actual package named `charmlibs`.
-It exists on PyPI solely to reserve the package name as a namespace for charm libraries,
-and to make the charm library easier to find.
+````{tip}
+To make a namespace package,
+nest your package in an empty directory with the namespace name,
+in this case `charmlibs`.
+For example, the file structure for your library might look like:
+```
+src/
+  charmlibs/
+    $libname/
+      __init__.py
+      ...
+tests/
+  unit/
+  integration/
+pyproject.toml
+```
+The `charmlibs` folder should not contain an `__init__.py` file.
+Likewise, there is no need to install an actual package named `charmlibs`
+-- this package does exist on PyPI,
+but solely to reserve the package name as a namespace for charm libraries,
+and to make charm library documentation easier to find.
+````
 
-If you have a dedicated repository for the charmlib, we recommend naming it `charmlibs-$libname` as well.
-For repositories containing several libraries, consider `$teamname-charmlibs`,
-with the individual packages following the naming and namespace recommendations.
-These naming  recommendations do not apply to other repository organisation schemes,
-but we still recomend the `charmlibs` namespace if your library is intended for public use.
+If you have a dedicated repository for the charmlib, we recommend naming it `charmlibs-$libname`.
+For repositories containing several libraries, consider `$teamname-charmlibs`.
 
-We don’t recommend using the `ops` or `charm` namespace for your charm libraries distributed as Python packages.
+Do use `charmlibs` namespace if your library is intended for public use.
+Don't use the `ops` or `charm` namespaces for your libraries.
 It will be easier for charmers to follow your code if the `ops` namespace is reserved for the `ops` package.
 Likewise, the `charms` namespace is best left for charmcraft managed libs.
 
-If your library is only intended to be used by your own charms,
-for example if you write a library to be used by the machine and Kubernetes versions of your charm,
-releasing a package on PyPI using this naming scheme may not be the right approach,
-as you don't necessarily want to advertise the library for public consumption.
+If your library should only be used by your own charms, you don't need to publish it to PyPI.
+In this case, you don't need to use the `charmlibs` namespace either,
+but feel free to do so if it's helpful.
+The next section suggests alternative distribution methods for this case.
 
 (python-package-distribution)=
 ## How to distribute your Python package

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -36,17 +36,20 @@ imported as `from charmlibs import $libname`.
 If you have a dedicated repository for the charmlib, we recommend naming it `charmlibs-$libname`.
 For a repository containing several libraries, consider naming the repository `$teamname-charmlibs`.
 
-Do use `charmlibs` namespace if your library is intended for public use.
+```{important}
 Don't use the `ops` or `charm` namespaces for your libraries.
 It will be easier for charmers to follow your code if the `ops` namespace is reserved for the `ops` package.
 Likewise, the `charms` namespace is best left for charmcraft managed libs.
+```
 
 If your library should only be used by your own charms, you don't need to publish it to PyPI.
 In this case, you don't need to use the `charmlibs` namespace either,
 but feel free to do so if it's helpful.
 The next section suggests alternative distribution methods for this case.
 
-````{tip}
+
+(namespace-package)=
+### Making a namespace package
 To make a namespace package,
 nest your package in an empty directory with the namespace name,
 in this case `charmlibs`.
@@ -67,7 +70,6 @@ Likewise, there is no need to install an actual package named `charmlibs`
 -- this package does exist on PyPI,
 but solely to reserve the package name as a namespace for charm libraries,
 and to make charm library documentation easier to find.
-````
 
 
 (python-package-distribution)=

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -133,18 +133,7 @@ You should also communicate this through the ["Development Status" Trove classif
 You can get started by distributing your library as a Python package with very little friction using GitHub.
 This is good for prototyping, or when first transitioning from a charmcraft-style library to a Python package,
 and may be a good fit for libraries that are intended for team-internal use.
-Once you’re done prototyping and the library is ready for external users, you’ll want to start using PyPI instead.
-
-Git dependencies are limited in that they don’t allow for sophisticated dependency resolution.
-You can only specify an exact reference (tag, commit, or branch).
-You can’t specify a version range.
-This is problematic if your library has dependencies,
-as having to request a specific version of your library makes it more likely that any dependency clashes will require manual intervention.
-It becomes even more problematic if your library may be depended on by other charm libraries.
-Requesting an exact hash or a branch tip may be sufficient for team-internal projects and prototyping,
-but proper versioning support is critical when sharing your library more widely,
-which will require promoting your package to PyPI.
-Tools that scan for security vulnerabilities may also struggle with such dependencies.
+If your library is intended for external users, consider whether PyPI would be a better choice.
 
 You’ll need to include `git` in your charm’s build dependencies to use a GitHub-hosted library in your charm:
 
@@ -162,6 +151,10 @@ ops @ git+https://github.com/canonical/operator@main
 
 You can specify any branch, tag, or commit after the `@`.
 If you leave it off, it will default to `@main`.
+You can’t specify a version range.
+This can make dependency resolution problematic for users,
+especially if your library is depended on by other charm libraries.
+Tools that scan versions for security vulnerabilities may also struggle with such dependencies.
 
 If your package is in a subdirectory of your repository
 (for example if you use a monorepo,

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -39,7 +39,7 @@ imported as `from charmlibs import $libname`
 The package should be a [namespace package](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/)
 using the `charmlibs` namespace.
 All this means is that your actual package is nested under an empty directory named `charmlibs`.
-Your file structure would look like ‘src/charmlibs/$libname/__init__.py’.
+Your file structure would look like `src/charmlibs/$libname/__init__.py`.
 There is no need to install the actual package named `charmlibs`.
 This exists on PyPI solely to reserve the package name as a namespace for charm libraries,
 and to aid charm library discoverability.

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -65,7 +65,7 @@ tests/
   integration/
 pyproject.toml
 ```
-The `charmlibs` folder should not contain an `__init__.py` file.
+The `charmlibs` folder must not contain an `__init__.py` file.
 Likewise, there is no need to install an actual package named `charmlibs`
 -- this package does exist on PyPI,
 but solely to reserve the package name as a namespace for charm libraries,
@@ -102,6 +102,7 @@ on:
       - 'v*.*.*'
 jobs:
   build-n-publish:
+     environment: pypi
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -113,7 +114,7 @@ jobs:
 ```
 
 Make sure that your repository only allows write access from trusted contributors.
-The team manager and another truster team member should be the package owners on PyPI,
+The team manager and another trusted team member should be the package owners on PyPI,
 using their Canonical email addresses.
 Make sure to also claim your package on [Test PyPI](https://test.pypi.org/),
 and setup a workflow for publishing there.
@@ -156,7 +157,7 @@ especially if your library is depended on by other charm libraries.
 Tools that scan versions for security vulnerabilities may also struggle with such dependencies.
 
 If your package is in a subdirectory of your repository,
-for example in a monorepo (like `charmlibs-pathops`),
+for example in a monorepo (like the example above),
 or when developing libraries alongside charms,
 you'll need to specify the subdirectory.
 If your library has a dedicated repository,

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -1,8 +1,7 @@
 (how-to-python-package)=
 # How to distribute charm libraries
 
-This guide details when and how you should create your charm libraries as Python packages
-(as opposed to {doc}`charmcraft-style charm libs <charmcraft:reference/commands/fetch-libs>`).
+This guide details when and how you should create your charm libraries as Python packages, instead of {doc}`Charmcraft-style charm libs <charmcraft:reference/commands/fetch-libs>`.
 
 
 (when-to-python-package)=
@@ -19,10 +18,10 @@ You should use a Python package for your charm library if:
 - You need to share modules between the machine and Kubernetes versions of a charm.
 
 For a relation library,
-it may still be worthwhile to use a charmcraft lib,
-since the library may be associated with a single charm,
-and there is existing infrastructure and documentation supporting this pattern.
-However, the reasons listed above should take priority even in this case.
+it may still be worthwhile to use a Charmcraft lib,
+since the library may be associated with a single charm.
+There's also infrastructure and documentation that supports this pattern.
+However, even in this case, the reasons listed above should take priority.
 
 
 (python-package-name)=
@@ -35,7 +34,7 @@ The distribution package name should be `charmlibs-$libname`,
 imported as `from charmlibs import $libname`.
 
 If you have a dedicated repository for the charmlib, we recommend naming it `charmlibs-$libname`.
-For repositories containing several libraries, consider `$teamname-charmlibs`.
+For a repository containing several libraries, consider naming the repository `$teamname-charmlibs`.
 
 Do use `charmlibs` namespace if your library is intended for public use.
 Don't use the `ops` or `charm` namespaces for your libraries.
@@ -79,11 +78,9 @@ improves discoverability,
 and makes it easier for users to install your library.
 However, it requires some additional work to publish,
 and is most appropriate if your library is intended for public use.
-You may find it useful to begin by distributing your package via a git url during development and team internal use.
-Using a git dependency
-or skipping distribution in favour of packing the local files with your charm
-may be appropriate if your library is purely for your own charms,
-and is not intended for external users.
+
+During development and team internal use, you may find it useful to begin by distributing your package by sharing a git URL.
+If your library is purely for your own charms and not intended for external users, it may be appropriate to use a git dependency or pack the local files with your charm.
 
 
 (python-package-distribution-pypi)=

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -224,15 +224,14 @@ The approach should be the same if you have multiple charms, (for example) `$cha
 (python-package-deps)=
 ## Dependencies
 
-Declare `~=` the lowest `2.X` `ops` version that you support.
-This is broadly equivalent to `>=2.X,==2.*`.
-This futureproofs you against potential future breaking changes in `ops` 3.
-There should be no need to declare a maximum `ops` version within the current `2.X` releases,
-as `ops` respects semantic versioning and has a strong promise of backwards compatibility.
+Your library is not required to depend on `ops`.
+If you do require `ops` as a dependency, specify `ops>=2.X,<3`,
+where 2.X is the lowest `ops` version that you support,
+and 3 is the next major version of `ops`,
+protecting your library from breaking changes.
 When creating a new library, it’s fine to declare the latest `ops` release as the minimum supported version,
-as charms are encouraged to always use the latest release of `ops`.
+as charms are encouraged to always use the latest version of `ops`.
 
-For other dependencies, ideally follow a similar approach.
+For other dependencies, ideally follow a similar approach:
 `>=` the lowest version that you need, `<` the next potential (or actual) breaking version.
-Keeping these dependencies permissive increases the number of charms that can use your library
-without worrying too much about their other dependencies.
+Keeping these dependencies permissive increases the number of charms that will be able to use your library.

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -1,10 +1,11 @@
-(how-to-python-packages)=
+(how-to-python-package)=
 # How to distribute charm libraries
 
 While there are multiple ways to share code between charms,
 including {doc}`charmcraft fetch-libs <charmcraft:reference/commands/fetch-libs>`,
 this how-to focuses specifically on Python packages.
 
+(when-to-python-package)=
 ## When to use a Python package
 
 If your library relies on any dependencies outside the Python standard library and the `ops` package, you should definitely use a Python package.
@@ -25,6 +26,7 @@ and there is existing infrastructure and documentation supporting this pattern.
 However, if the relation library relies on any additional dependencies,
 it would still be better to make it a Python package.
 
+(python-package-name)=
 ## Naming and namespacing your Python package
 
 For charm libraries distributed as Python packages,
@@ -56,6 +58,7 @@ for example if you write a library to be used by the machine and Kubernetes vers
 releasing a package on PyPI using this naming scheme may not be the right approach,
 as you don't necessarily want to advertise the library for public consumption.
 
+(python-package-distribution)=
 ## How to distribute your Python package
 
 Distributing your package on PyPI has the most benefits.
@@ -65,6 +68,7 @@ or skipping distribution in favour of packing the local package
 may be appropriate if your library is purely for your own charms,
 and is not intended for external users.
 
+(python-package-distribution-pypi)=
 ### PyPI
 
 Use [trusted publishing](https://docs.pypi.org/trusted-publishers/) to publish directly from your github repository.
@@ -86,6 +90,7 @@ Therefore, if you’re going to publish on PyPI, we highly recommend that you us
 A non-dev/alpha/beta/etc qualified 1.x release to PyPI signifies that your library is ready for public consumption.
 You should also communicate this through the ["Development Status" Trove classifier](https://pypi.org/classifiers/) in your `pyproject.toml`.
 
+(python-package-distribution-git)=
 ### Git
 
 You can get started by distributing your library as a Python package with very little friction using GitHub.
@@ -146,6 +151,7 @@ dependencies = [
 
 For `poetry` see [here](https://python-poetry.org/docs/dependency-specification/#git-dependencies).
 
+(python-package-distribution-local)=
 ### Local Files
 
 If you're developing a Python package in the same repository as your charm(s),
@@ -183,6 +189,7 @@ charmcraft pack
 
 The approach should be the same if you have multiple charms, (for example) `$charm-kubernetes` and `$charm-machine`, or even multiple packages.
 
+(python-package-deps)=
 ## Dependencies
 
 Declare `~=` the lowest `2.X` `ops` version that you support.

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -85,13 +85,30 @@ and is not intended for external users.
 (python-package-distribution-pypi)=
 ### PyPI
 
-Use [trusted publishing](https://docs.pypi.org/trusted-publishers/) to publish directly from your github repository.
-You can use the [actions/attest-build-provenance](https://github.com/actions/attest-build-provenance)
-and [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish) actions in your workflows.
-Trigger the workflow based on a version tag being pushed.
-Feel free to check out this project's workflows for an example.
-Make sure that your repository only allows trusted contributors write access.
+To publish your library on PyPI,
+set up [trusted publishing](https://docs.pypi.org/trusted-publishers/) on PyPI,
+and create a Github workflow triggered by a version tag.
+For example:
 
+```yaml
+# publish.yaml
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+jobs:
+  build-n-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv build
+      - uses: pypa/gh-action-pypi-publish@release/v1
+```
+
+Make sure that your repository only allows trusted contributors write access.
 The team manager and another truster team member should be the package owners on PyPI,
 using their Canonical email addresses.
 Make sure to also claim your package on [Test PyPI](https://test.pypi.org/),

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -4,6 +4,7 @@
 This guide details when and how you should create your charm libraries as Python packages
 (as opposed to {doc}`charmcraft-style charm libs <charmcraft:reference/commands/fetch-libs>`).
 
+
 (when-to-python-package)=
 ## When to use a Python package
 
@@ -22,6 +23,7 @@ it may still be worthwhile to use a charmcraft lib,
 since the library may be associated with a single charm,
 and there is existing infrastructure and documentation supporting this pattern.
 However, the reasons listed above should take priority even in this case.
+
 
 (python-package-name)=
 ## Naming and namespacing your Python package
@@ -68,6 +70,7 @@ but solely to reserve the package name as a namespace for charm libraries,
 and to make charm library documentation easier to find.
 ````
 
+
 (python-package-distribution)=
 ## How to distribute your Python package
 
@@ -81,6 +84,7 @@ Using a git dependency
 or skipping distribution in favour of packing the local files with your charm
 may be appropriate if your library is purely for your own charms,
 and is not intended for external users.
+
 
 (python-package-distribution-pypi)=
 ### PyPI
@@ -121,6 +125,7 @@ Therefore, if you’re going to publish on PyPI, we highly recommend that you us
 
 A non-dev/alpha/beta/etc qualified 1.x release to PyPI signifies that your library is ready for public consumption.
 You should also communicate this through the ["Development Status" Trove classifier](https://pypi.org/classifiers/) in your `pyproject.toml`.
+
 
 (python-package-distribution-git)=
 ### Git
@@ -183,6 +188,7 @@ dependencies = [
 
 For `poetry` see [here](https://python-poetry.org/docs/dependency-specification/#git-dependencies).
 
+
 (python-package-distribution-local)=
 ### Local Files
 
@@ -203,15 +209,10 @@ $repo/
 ```
 
 Then you could leave `$package` out of your `$charm/pyproject.toml` during development.
-
-To provision a development virtual environment in `$repo` you could `uv venv` and then `uv pip install -e ./$charm -e ./$package`.
-Using editable installs ensures that the virtual environment reflects all changes made to either `$charm` or `$package`.
-To provision a development virtual environment in `$charm` you could `uv sync` and then `uv pip install -e ../$package`.
-Since `$package` doesn't depend on `$charm`, its development virtual environment doesn't require any special commands, just a `uv sync`.
-
-When it comes time to pack `$charm` for a release or testing, you could do something like this:
+When it comes time to pack `$charm` for release or integration testing, you could do something like this:
 
 ```bash
+cd $repo
 cp -r ./$charm ./pack-$charm
 cp -r ./$package ./pack-$charm/
 cd ./pack-$charm
@@ -219,7 +220,29 @@ uv add ./$package
 charmcraft pack
 ```
 
-The approach should be the same if you have multiple charms, (for example) `$charm-kubernetes` and `$charm-machine`, or even multiple packages.
+To provision virtual environments for development (including linting and unit testing) we can use editable installs.
+For a `$repo` wide virtual environment for conveniently working on both `$package` and `$charm`, you could do this:
+```bash
+cd $repo
+uv venv
+uv pip install -e ./$charm -e ./$package
+```
+Using editable installs ensures that the virtual environment reflects all changes made to either `$charm` or `$package`.
+You can then point your editor to the python interpreter in `.venv`, or [activate it manually](https://docs.python.org/3/library/venv.html#how-venvs-work).
+To create a virtual environment with a specific python version, use the `--python` flag or define it in a `$repo` level `pyproject.toml`.
+If you take this approach, a `$repo` level `pyproject.toml` is a good place to put your common dev dependencies like `ruff` and `codespell`.
+You can remove the created `.venv` directory to start afresh.
+
+If you wanted a virtual environment for `$charm` specifically, you could do:
+```bash
+cd $charm
+uv sync  # install deps from $charm/pyproject.toml
+uv pip install -e ../$package
+```
+Since `$package` doesn't depend on `$charm`, its development virtual environment doesn't require any special commands, just a `uv sync`.
+
+The approach should be the same if you have multiple charms, (for example `$charm-kubernetes` and `$charm-machine`), or multiple packages.
+
 
 (python-package-deps)=
 ## Dependencies

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -1,8 +1,7 @@
 (how-to-python-package)=
 # How to distribute charm libraries
 
-This guide details when and how you should create your charm libraries as Python packages,
-instead of {doc}`Charmcraft-style charm libs <charmcraft:reference/commands/fetch-libs>`.
+This guide details when and how you should create your charm libraries as Python packages, instead of {doc}`Charmcraft-style charm libs <charmcraft:reference/commands/fetch-libs>`.
 
 
 (when-to-python-package)=
@@ -18,43 +17,27 @@ You should use a Python package for your charm library if:
 
 - You need to share modules between the machine and Kubernetes versions of a charm.
 
-For a relation library,
-it may still be worthwhile to use a Charmcraft lib,
-since the library may be associated with a single charm.
-There's also infrastructure and documentation that supports this pattern.
-However, even in this case, the reasons listed above should take priority.
+For a relation library, it may still be worthwhile to use a Charmcraft lib, since the library may be associated with a single charm. There's also infrastructure and documentation that supports this pattern. However, even in this case, the reasons listed above should take priority.
 
 
 (python-package-name)=
 ## Naming and namespacing your Python package
 
-For charm libraries intended for public use and distributed as Python packages,
-the library should be a [namespace package](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/)
-using the `charmlibs` namespace.
-The distribution package name should be `charmlibs-$libname`,
-imported as `from charmlibs import $libname`.
+For charm libraries intended for public use and distributed as Python packages, the library should be a [namespace package](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/) using the `charmlibs` namespace. The distribution package name should be `charmlibs-$libname`, imported as `from charmlibs import $libname`.
 
-If you have a dedicated repository for the charmlib, we recommend naming it `charmlibs-$libname`.
-For a repository containing several libraries, consider naming the repository `$teamname-charmlibs`.
+If you have a dedicated repository for the charmlib, we recommend naming it `charmlibs-$libname`. For a repository containing several libraries, consider naming the repository `$teamname-charmlibs`.
 
 ```{important}
-Don't use the `ops` or `charm` namespaces for your libraries.
-It will be easier for charmers to follow your code if the `ops` namespace is reserved for the `ops` package.
-Likewise, the `charms` namespace is best left for charmcraft managed libs.
+Don't use the `ops` or `charm` namespaces for your libraries. It will be easier for charmers to follow your code if the `ops` namespace is reserved for the `ops` package. Likewise, the `charms` namespace is best left for charmcraft managed libs.
 ```
 
-If your library should only be used by your own charms, you don't need to publish it to PyPI.
-In this case, you don't need to use the `charmlibs` namespace either,
-but feel free to do so if it's helpful.
-The next section suggests alternative distribution methods for this case.
+If your library should only be used by your own charms, you don't need to publish it to PyPI. In this case, you don't need to use the `charmlibs` namespace either, but feel free to do so if it's helpful. The next section suggests alternative distribution methods for this case.
 
 
 (namespace-package)=
 ### Making a namespace package
-To make a namespace package,
-nest your package in an empty directory with the namespace name,
-in this case `charmlibs`.
-For example, the file structure for your library might look like this:
+To make a namespace package, nest your package in an empty directory with the namespace name, in this case `charmlibs`. For example, the file structure for your library might look like this:
+
 ```
 src/
   charmlibs/
@@ -66,33 +49,22 @@ tests/
   integration/
 pyproject.toml
 ```
-The `charmlibs` folder must not contain an `__init__.py` file.
-Likewise, there is no need to install an actual package named `charmlibs`
--- this package does exist on PyPI,
-but solely to reserve the package name as a namespace for charm libraries,
-and to make charm library documentation easier to find.
+
+The `charmlibs` folder must not contain an `__init__.py` file. Likewise, there is no need to install an actual package named `charmlibs` -- this package does exist on PyPI, but solely to reserve the package name as a namespace for charm libraries, and to make charm library documentation easier to find.
 
 
 (python-package-distribution)=
 ## How to distribute your Python package
 
-Distributing your package on PyPI allows your users to use dependency ranges,
-improves discoverability,
-and makes it easier for users to install your library.
-However, it requires some additional work to publish,
-and is most appropriate if your library is intended for public use.
+Distributing your package on PyPI allows your users to use dependency ranges, improves discoverability, and makes it easier for users to install your library. However, it requires some additional work to publish, and is most appropriate if your library is intended for public use.
 
-During development and team internal use, you may find it useful to begin by distributing your package by sharing a git URL.
-If your library is purely for your own charms and not intended for external users, it may be appropriate to use a git dependency or pack the local files with your charm.
+During development and team internal use, you may find it useful to begin by distributing your package by sharing a git URL. If your library is purely for your own charms and not intended for external users, it may be appropriate to use a git dependency or pack the local files with your charm.
 
 
 (python-package-distribution-pypi)=
 ### PyPI
 
-To publish your library on PyPI,
-set up [trusted publishing](https://docs.pypi.org/trusted-publishers/) on PyPI,
-and create a Github workflow triggered by a version tag.
-For example:
+To publish your library on PyPI, set up [trusted publishing](https://docs.pypi.org/trusted-publishers/) on PyPI, and create a Github workflow triggered by a version tag. For example:
 
 <!-- TODO: use exact commits hashes in this workflow example -->
 ```yaml
@@ -114,27 +86,17 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
 ```
 
-Make sure that your repository only allows write access from trusted contributors.
-The team manager and another trusted team member should be the package owners on PyPI,
-using their Canonical email addresses.
-Make sure to also claim your package on [Test PyPI](https://test.pypi.org/),
-and setup a workflow for publishing there.
-All team members can be owners on Test PyPI.
+Make sure that your repository only allows write access from trusted contributors. The team manager and another trusted team member should be the package owners on PyPI, using their Canonical email addresses. Make sure to also claim your package on [Test PyPI](https://test.pypi.org/), and setup a workflow for publishing there. All team members can be owners on Test PyPI.
 
-A major benefit of publishing on PyPI is that users of your library can specify version ranges in their dependencies.
-Therefore, if you’re going to publish on PyPI, we highly recommend that you use semantic versioning for your library.
+A major benefit of publishing on PyPI is that users of your library can specify version ranges in their dependencies. Therefore, if you’re going to publish on PyPI, we highly recommend that you use semantic versioning for your library.
 
-A 1.x release to PyPI that isn't qualified with dev/alpha/beta/etc signifies that your library is ready for public consumption.
-You should also communicate this through the ["Development Status" Trove classifier](https://pypi.org/classifiers/) in your `pyproject.toml`.
+A 1.x release to PyPI that isn't qualified with dev/alpha/beta/etc signifies that your library is ready for public consumption. You should also communicate this through the ["Development Status" Trove classifier](https://pypi.org/classifiers/) in your `pyproject.toml`.
 
 
 (python-package-distribution-git)=
 ### Git
 
-You can get started by distributing your library as a Python package with very little friction using GitHub.
-This is good for prototyping, or when first transitioning from a charmcraft-style library to a Python package,
-and may be a good fit for libraries that are intended for team-internal use.
-If your library is intended for external users, consider whether PyPI would be a better choice.
+You can get started by distributing your library as a Python package with very little friction using GitHub. This is good for prototyping, or when first transitioning from a charmcraft-style library to a Python package, and may be a good fit for libraries that are intended for team-internal use. If your library is intended for external users, consider whether PyPI would be a better choice.
 
 You’ll need to include `git` in your charm’s build dependencies:
 
@@ -150,33 +112,17 @@ Then you can specify the dependency in your requirements:
 charmlibs-pathops @ git+https://github.com/canonical/charmtech-charmlibs@main#subdirectory=pathops
 ```
 
-You can specify any branch, tag, or commit after the `@`.
-If you leave it off, it will default to `@main`.
-You can’t specify a version range.
-This can make dependency resolution problematic for users,
-especially if your library is depended on by other charm libraries.
-Tools that scan versions for security vulnerabilities may also struggle with such dependencies.
+You can specify any branch, tag, or commit after the `@`. If you leave it off, it will default to `@main`. You can’t specify a version range. This can make dependency resolution problematic for users, especially if your library is depended on by other charm libraries. Tools that scan versions for security vulnerabilities may also struggle with such dependencies.
 
-If your package is in a subdirectory of your repository,
-for example in a monorepo (like the example above),
-or when developing libraries alongside charms,
-you'll need to specify the subdirectory.
-If your library has a dedicated repository,
-leave off the subdirectory and it will default to the repository root.
+If your package is in a subdirectory of your repository, for example in a monorepo (like the example above), or when developing libraries alongside charms, you'll need to specify the subdirectory. If your library has a dedicated repository, leave off the subdirectory and it will default to the repository root.
 
-In `pyproject.toml`, quote the entire string starting `charmlibs-pathops @ git+...` in your dependencies list.
-Alternatively, use `uv add git+...` to have `uv` add `charmlibs-pathops` to your dependencies list and the git reference to `tool.uv.sources`.
-For `poetry` see [the `poetry` docs](https://python-poetry.org/docs/dependency-specification/#git-dependencies).
+In `pyproject.toml`, quote the entire string starting `charmlibs-pathops @ git+...` in your dependencies list. Alternatively, use `uv add git+...` to have `uv` add `charmlibs-pathops` to your dependencies list and the git reference to `tool.uv.sources`. For `poetry` see [the `poetry` docs](https://python-poetry.org/docs/dependency-specification/#git-dependencies).
 
 
 (python-package-distribution-local)=
 ### Local files
 
-If you're developing a Python package in the same repository as your charm(s),
-it may be simplest to skip distribution and use the local files when packing the charm.
-This way, assuming a freshly checked out copy of the repository,
-the git commit fully specifies the contents of both your charm code and the package.
-For example, if you had the following structure:
+If you're developing a Python package in the same repository as your charm(s), it may be simplest to skip distribution and use the local files when packing the charm. This way, assuming a freshly checked out copy of the repository, the git commit fully specifies the contents of both your charm code and the package. For example, if you had the following structure:
 
 ```
 $repo/
@@ -188,8 +134,7 @@ $repo/
         pyproject.toml
 ```
 
-Then you could leave `$package` out of your `$charm/pyproject.toml` during development.
-When it comes time to pack `$charm` for release or integration testing, you could do something like this:
+Then you could leave `$package` out of your `$charm/pyproject.toml` during development. When it comes time to pack `$charm` for release or integration testing, you could do something like this:
 
 ```bash
 cd $repo
@@ -200,26 +145,26 @@ uv add ./$package
 charmcraft pack
 ```
 
-To provision virtual environments for development (including linting and unit testing) we can use editable installs.
-For a `$repo` wide virtual environment for conveniently working on both `$package` and `$charm`, you could do this:
+To provision virtual environments for development (including linting and unit testing) we can use editable installs. For a `$repo` wide virtual environment for conveniently working on both `$package` and `$charm`, you could do this:
+
 ```bash
 cd $repo
 uv venv
 uv pip install -e ./$charm -e ./$package
 ```
-Using editable installs ensures that the virtual environment reflects all changes made to either `$charm` or `$package`.
-You can then point your editor to the python interpreter in `.venv`, or [activate it manually](https://docs.python.org/3/library/venv.html#how-venvs-work).
 
-To create a virtual environment with a specific python version, use the `--python` flag or define it in a `$repo` level `pyproject.toml`.
-If you take this approach, a `$repo` level `pyproject.toml` is a good place to put your common dev dependencies like `ruff` and `codespell`.
-You can remove the created `.venv` directory to start afresh.
+Using editable installs ensures that the virtual environment reflects all changes made to either `$charm` or `$package`. You can then point your editor to the python interpreter in `.venv`, or [activate it manually](https://docs.python.org/3/library/venv.html#how-venvs-work).
+
+To create a virtual environment with a specific python version, use the `--python` flag or define it in a `$repo` level `pyproject.toml`. If you take this approach, a `$repo` level `pyproject.toml` is a good place to put your common dev dependencies like `ruff` and `codespell`. You can remove the created `.venv` directory to start afresh.
 
 If you wanted a virtual environment for `$charm` specifically, you could do:
+
 ```bash
 cd $charm
 uv sync  # install deps from $charm/pyproject.toml
 uv pip install -e ../$package
 ```
+
 Since `$package` doesn't depend on `$charm`, its development virtual environment doesn't require an editable install:
 
 ```bash
@@ -233,14 +178,6 @@ The approach should be the same if you have multiple charms, (for example `$char
 (python-package-deps)=
 ## Dependencies
 
-Your library is not required to depend on `ops`.
-If you do require `ops` as a dependency, specify `ops>=2.X,<3`,
-where 2.X is the lowest `ops` version that you support,
-and 3 is the next major version of `ops`.
-This protects your library from breaking changes.
-When creating a new library, it’s fine to declare the latest `ops` release as the minimum supported version,
-as charms are encouraged to always use the latest version of `ops`.
+Your library is not required to depend on `ops`. If you do require `ops` as a dependency, specify `ops>=2.X,<3`, where 2.X is the lowest `ops` version that you support, and 3 is the next major version of `ops`. This protects your library from breaking changes. When creating a new library, it’s fine to declare the latest `ops` release as the minimum supported version, as charms are encouraged to always use the latest version of `ops`.
 
-For other dependencies, ideally follow a similar approach:
-`>=` the lowest version that you need, `<` the next potential (or actual) breaking version.
-Keeping these dependencies permissive increases the number of charms that will be able to use your library.
+For other dependencies, ideally follow a similar approach: `>=` the lowest version that you need, `<` the next potential (or actual) breaking version. Keeping these dependencies permissive increases the number of charms that will be able to use your library.

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -146,7 +146,7 @@ but proper versioning support is critical when sharing your library more widely,
 which will require promoting your package to PyPI.
 Tools that scan for security vulnerabilities may also struggle with such dependencies.
 
-You’ll need to include git in your charm’s build dependencies to use a GitHub-hosted library in your charm:
+You’ll need to include `git` in your charm’s build dependencies to use a GitHub-hosted library in your charm:
 
 ```yaml
 parts:
@@ -172,15 +172,9 @@ or collect your libraries into a single repository
 ops-testing @ git+https://github.com/canonical/operator@main#subdirectory=testing
 ```
 
-If you're using `pyproject.toml` (recommended!):
-
-```toml
-[project]
-dependencies = [
-  "ops-testing @ git+https://github.com/canonical/operator@main#subdirectory=testing",
-]
-```
-
+In `pyproject.toml`, quote the entire string above in your dependencies list,
+or use `uv add git+...` to have `uv` add `charmlibs-pathops` to your dependencies list,
+and the git referece to `tool.uv.sources`.
 For `poetry` see [here](https://python-poetry.org/docs/dependency-specification/#git-dependencies).
 
 

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -1,9 +1,8 @@
 (how-to-python-package)=
 # How to distribute charm libraries
 
-While there are multiple ways to share code between charms,
-including {doc}`charmcraft fetch-libs <charmcraft:reference/commands/fetch-libs>`,
-this how-to focuses specifically on Python packages.
+This guide details when and how you should create your charm libraries as Python packages
+(as opposed to {doc}`charmcraft-style charm libs <charmcraft:reference/commands/fetch-libs>`).
 
 (when-to-python-package)=
 ## When to use a Python package

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -42,7 +42,7 @@ All this means is that your actual package is nested under an empty directory na
 Your file structure would look like `src/charmlibs/$libname/__init__.py`.
 There is no need to install the actual package named `charmlibs`.
 It exists on PyPI solely to reserve the package name as a namespace for charm libraries,
-and to aid charm library discoverability.
+and to make the charm library easier to find.
 
 If you have a dedicated repository for the charmlib, we recommend naming it `charmlibs-$libname` as well.
 For repositories containing several libraries, consider `$teamname-charmlibs`,
@@ -95,7 +95,7 @@ You should also communicate this through the ["Development Status" Trove classif
 ### Git
 
 You can get started by distributing your library as a Python package with very little friction using GitHub.
-This is good for prototyping, or when first transitioning from a charm-lib to a Python package,
+This is good for prototyping, or when first transitioning from a charmcraft-style library to a Python package,
 and may be a good fit for libraries that are intended for team-internal use.
 Once you’re done prototyping and the library is ready for external users, you’ll want to start using PyPI instead.
 

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -219,7 +219,12 @@ cd $charm
 uv sync  # install deps from $charm/pyproject.toml
 uv pip install -e ../$package
 ```
-Since `$package` doesn't depend on `$charm`, its development virtual environment doesn't require any special commands, just a `uv sync`.
+Since `$package` doesn't depend on `$charm`, its development virtual environment doesn't require an editable install:
+
+```bash
+cd $package
+uv sync  # install deps from $package/pyproject.toml
+```
 
 The approach should be the same if you have multiple charms, (for example `$charm-kubernetes` and `$charm-machine`), or multiple packages.
 

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -90,6 +90,7 @@ set up [trusted publishing](https://docs.pypi.org/trusted-publishers/) on PyPI,
 and create a Github workflow triggered by a version tag.
 For example:
 
+<!-- TODO: use exact commits hashes in this workflow example -->
 ```yaml
 # .github/workflows/publish.yaml
 on:

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -49,7 +49,7 @@ The next section suggests alternative distribution methods for this case.
 To make a namespace package,
 nest your package in an empty directory with the namespace name,
 in this case `charmlibs`.
-For example, the file structure for your library might look like:
+For example, the file structure for your library might look like this:
 ```
 src/
   charmlibs/

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -146,7 +146,7 @@ parts:
 Then you can specify the dependency in your requirements like this:
 
 ```
-ops @ git+https://github.com/canonical/operator@main
+charmlibs-pathops @ git+https://github.com/canonical/charmtech-charmlibs@main#subdirectory=pathops
 ```
 
 You can specify any branch, tag, or commit after the `@`.
@@ -156,14 +156,12 @@ This can make dependency resolution problematic for users,
 especially if your library is depended on by other charm libraries.
 Tools that scan versions for security vulnerabilities may also struggle with such dependencies.
 
-If your package is in a subdirectory of your repository
-(for example if you use a monorepo,
-or collect your libraries into a single repository
--- or if you’re just developing in an existing repository while prototyping):
-
-```
-ops-testing @ git+https://github.com/canonical/operator@main#subdirectory=testing
-```
+If your package is in a subdirectory of your repository,
+for example in a monorepo (like `charmlibs-pathops`),
+or when developing libraries alongside charms,
+you'll need to specify the subdirectory.
+If your library has a dedicated repository,
+leave off the subdirectory and it will default to the repository root.
 
 In `pyproject.toml`, quote the entire string above in your dependencies list,
 or use `uv add git+...` to have `uv` add `charmlibs-pathops` to your dependencies list,

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -91,7 +91,7 @@ and create a Github workflow triggered by a version tag.
 For example:
 
 ```yaml
-# publish.yaml
+# .github/workflows/publish.yaml
 on:
   push:
     tags:

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -32,6 +32,19 @@ using the `charmlibs` namespace.
 The distribution package name should be `charmlibs-$libname`,
 imported as `from charmlibs import $libname`.
 
+If you have a dedicated repository for the charmlib, we recommend naming it `charmlibs-$libname`.
+For repositories containing several libraries, consider `$teamname-charmlibs`.
+
+Do use `charmlibs` namespace if your library is intended for public use.
+Don't use the `ops` or `charm` namespaces for your libraries.
+It will be easier for charmers to follow your code if the `ops` namespace is reserved for the `ops` package.
+Likewise, the `charms` namespace is best left for charmcraft managed libs.
+
+If your library should only be used by your own charms, you don't need to publish it to PyPI.
+In this case, you don't need to use the `charmlibs` namespace either,
+but feel free to do so if it's helpful.
+The next section suggests alternative distribution methods for this case.
+
 ````{tip}
 To make a namespace package,
 nest your package in an empty directory with the namespace name,
@@ -54,19 +67,6 @@ Likewise, there is no need to install an actual package named `charmlibs`
 but solely to reserve the package name as a namespace for charm libraries,
 and to make charm library documentation easier to find.
 ````
-
-If you have a dedicated repository for the charmlib, we recommend naming it `charmlibs-$libname`.
-For repositories containing several libraries, consider `$teamname-charmlibs`.
-
-Do use `charmlibs` namespace if your library is intended for public use.
-Don't use the `ops` or `charm` namespaces for your libraries.
-It will be easier for charmers to follow your code if the `ops` namespace is reserved for the `ops` package.
-Likewise, the `charms` namespace is best left for charmcraft managed libs.
-
-If your library should only be used by your own charms, you don't need to publish it to PyPI.
-In this case, you don't need to use the `charmlibs` namespace either,
-but feel free to do so if it's helpful.
-The next section suggests alternative distribution methods for this case.
 
 (python-package-distribution)=
 ## How to distribute your Python package

--- a/_docs/how-to/python-package.md
+++ b/_docs/how-to/python-package.md
@@ -145,7 +145,7 @@ If you're using `pyproject.toml` (recommended!):
 ```toml
 [project]
 dependencies = [
-  “ops-testing @ git+https://github.com/canonical/operator@main#subdirectory=testing”,
+  "ops-testing @ git+https://github.com/canonical/operator@main#subdirectory=testing",
 ]
 ```
 

--- a/_docs/how-to/python-packages.md
+++ b/_docs/how-to/python-packages.md
@@ -1,0 +1,35 @@
+(how-to-python-packages)=
+# How to distribute charm libraries
+
+While there are multiple ways to share code between charms,
+including {doc}`charmcraft fetch-libs <charmcraft:reference/commands/fetch-libs>`,
+this how-to focuses specifically on Python packages.
+
+## When to use a Python package
+
+If your library relies on any dependencies outside the Python standard library and the `ops` package, you should definitely use a Python package.
+
+If a charm library seems like it will be difficult to manage as a single file, this is another strong sign that it should be a Python package.
+
+For any new libraries that are not logically associated with a single charm,
+including those that are used by both the charmed machine and Kubernetes versions of a piece of software,
+consider if using a Python package will make your life easier.
+This is especially likely to be the case if you are sharing multiple modules between machine and Kubernetes versions of a charm,
+where the individual modules would not obviously be separate Python packages
+-- in this case a single Python package will be easier to manage than multiple (perhaps interdependent) charmcraft libs.
+
+The main case where charmcraft libs are likely to be a good alternative to a Python package is for relations.
+In this case, the library is associated with a specific charm,
+it is likely to be simple enough for a single file (as a lot of logic likely lives in the related charms),
+and there is existing infrastructure and documentation supporting this pattern.
+However, if the relation library relies on any additional dependencies,
+it would still be better to make it a Python package.
+
+## How to distribute your Python package
+
+Distributing your package on PyPI has the most benefits.
+However, you may find it useful to begin by distributing your package via a git url during development and internal use.
+
+### PyPI
+
+### Git

--- a/_docs/how-to/python-packages.md
+++ b/_docs/how-to/python-packages.md
@@ -27,13 +27,173 @@ it would still be better to make it a Python package.
 
 ## Naming and namespacing your Python package
 
+For charm libraries distributed as Python packages,
+we recommend using the `charmlibs` namespace,
+particularly if your library is intended for other charmers to use.
+The package name should be `charmlibs-$libname`,
+imported as `from charmlibs import $libname`
+(or `import charmlibs.$libname as $libname` if you're stuck on an older `pyright` version that complains about the other form).
 
+The package should be a [namespace package](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/)
+using the `charmlibs` namespace.
+All this means is that your actual package is nested under an empty directory named `charmlibs`.
+Your file structure would look like ‘src/charmlibs/$libname/__init__.py’.
+There is no need to install the actual package named `charmlibs`.
+This exists on PyPI solely to reserve the package name as a namespace for charm libraries,
+and to aid charm library discoverability.
+
+If you have a dedicated repository for the charmlib, we recommend naming it `charmlibs-$libname` as well.
+For repositories containing several libraries, consider `$teamname-charmlibs`,
+with the individual packages should still follow the naming and namespace recommendations.
+These recommendations do not apply to other repository organisation schemes.
+
+We don’t recommend using the `ops` or `charm` namespace for your charm libraries distributed as Python packages.
+It will be easier for charmers to follow your code if the `ops` namespace is reserved for the `ops` package.
+Likewise, the `charms` namespace is best left for charmcraft managed libs.
+
+If your library is only intended to be used by your own charms,
+for example if you write a library to be used by the machine and Kubernetes versions of your charm,
+releasing a package on PyPI using this naming scheme may not be the right approach,
+as you don't necessarily want to advertise the library for public consumption.
 
 ## How to distribute your Python package
 
 Distributing your package on PyPI has the most benefits.
 However, you may find it useful to begin by distributing your package via a git url during development and internal use.
+Using a git dependency
+or skipping distribution in favour of packing the local package
+may be appropriate if your library is purely for your own charms,
+and is not intended for external users.
 
 ### PyPI
 
+Use [trusted publishing](https://docs.pypi.org/trusted-publishers/) to publish directly from your github repository.
+You can use the [actions/attest-build-provenance](https://github.com/actions/attest-build-provenance)
+and [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish) actions in your workflows.
+Trigger the workflow based on a version tag being pushed.
+Feel free to check out this project's workflows for an example.
+Make sure that your repository only allows trusted contributors write access.
+
+The team manager and another truster team member should be the package owners on PyPI,
+using their Canonical email addresses.
+Make sure to also claim your package on [Test PyPI](https://test.pypi.org/),
+and setup a workflow for publishing there.
+All team members can be owners on Test PyPI.
+
+A major benefit of publishing on PyPI is that users of your library can specify version ranges in their dependencies.
+Therefore, if you’re going to publish on PyPI, we highly recommend that you use semantic versioning for your library.
+
+A non-dev/alpha/beta/etc qualified 1.x release to PyPI signifies that your library is ready for public consumption.
+You should also communicate this through the ["Development Status" Trove classifier](https://pypi.org/classifiers/) in your `pyproject.toml`.
+
 ### Git
+
+You can get started by distributing your library as a Python package with very little friction using GitHub.
+This is good for prototyping, or when first transitioning from a charm-lib to a Python package,
+and may be a good fit for libraries that are intended for team-internal use.
+Once you’re done prototyping and the library is ready for external users, you’ll want to start using PyPI instead.
+
+Git dependencies are limited in that they don’t allow for sophisticated dependency resolution.
+You can only specify an exact reference (tag, commit, or branch).
+You can’t specify a version range.
+This is problematic if your library has dependencies,
+as having to request a specific version of your library makes it more likely that any dependency clashes will require manual intervention.
+It becomes even more problematic if your library may be depended on by other charm libraries.
+Requesting an exact hash or a branch tip may be sufficient for team-internal projects and prototyping,
+but proper versioning support is critical when sharing your library more widely,
+which will require promoting your package to PyPI.
+Tools that scan for security vulnerabilities may also struggle with such dependencies.
+
+You’ll need to include git in your charm’s build dependencies to use a GitHub-hosted library in your charm:
+
+```yaml
+parts:
+  charm:
+    build-packages: [git]
+```
+
+Then you can specify the dependency in your requirements like this:
+
+```
+ops @ git+https://github.com/canonical/operator@main
+```
+
+If you don’t specify a branch or tag, it will default to `main`.
+This is probably sufficient for early prototyping and internal use.
+If you push git tags for releases or do releases on GitHub, you could point to the exact release tag, e.g. `@v2.18.1`.
+Another approach which could be useful for prototyping would be to pin on a branch,
+e.g. `stable/candidate/beta/edge`, `dev/main`, `v0/v1/v2`, etc.
+These approaches may be useful as your library stabilises internally, but if you find yourself thinking about a scheme like this,
+it’s probably a sign to switch to PyPI and use semantic versioning.
+
+If your package is in a subdirectory of your repository
+(for example if you use a monorepo,
+or collect your libraries into a single repository
+-- or if you’re just developing in an existing repository while prototyping):
+
+```
+ops-testing @ git+https://github.com/canonical/operator@main#subdirectory=testing
+```
+
+If you're using `pyproject.toml` (recommended!):
+
+```toml
+[project]
+dependencies = [
+  “ops-testing @ git+https://github.com/canonical/operator@main#subdirectory=testing”,
+]
+```
+
+For `poetry` see [here](https://python-poetry.org/docs/dependency-specification/#git-dependencies).
+
+### Local Files
+
+If you're developing a Python package in the same repository as your charm(s),
+it may be simplest to skip distribution and use the local files when packing the charm.
+This way, assuming a freshly checked out copy of the repository,
+the git commit fully specifies the contents of both your charm code and the package.
+For example, if you had the following structure:
+
+```
+$repo/
+    $charm/
+        src/charm.py
+        pyproject.toml
+    $package/
+        src/charmlibs/$libname/__init__.py
+        pyproject.toml
+```
+
+Then you could leave `$package` out of your `$charm/pyproject.toml` during development.
+
+To provision a development virtual environment in `$repo` you could `uv venv` and then `uv pip install -e ./$charm -e ./$package`.
+Using editable installs ensures that the virtual environment reflects all changes made to either `$charm` or `$package`.
+To provision a development virtual environment in `$charm` you could `uv sync` and then `uv pip install -e ../$package`.
+Since `$package` doesn't depend on `$charm`, its development virtual environment doesn't require any special commands, just a `uv sync`.
+
+When it comes time to pack `$charm` for a release or testing, you could do something like this:
+
+```bash
+cp -r ./$charm ./pack-$charm
+cp -r ./$package ./pack-$charm/
+cd ./pack-$charm
+uv add ./$package
+charmcraft pack
+```
+
+The approach should be the same if you have multiple charms, (for example) `$charm-kubernetes` and `$charm-machine`, or even multiple packages.
+
+## Dependencies
+
+Declare `~=` the lowest `2.X` `ops` version that you support.
+This is broadly equivalent to `>=2.X,==2.*`.
+This futureproofs you against potential future breaking changes in `ops` 3.
+There should be no need to declare a maximum `ops` version within the current `2.X` releases,
+as `ops` respects semantic versioning and has a strong promise of backwards compatibility.
+When creating a new library, it’s fine to declare the latest `ops` release as the minimum supported version,
+as charms are encouraged to always use the latest release of `ops`.
+
+For other dependencies, ideally follow a similar approach.
+`>=` the lowest version that you need, `<` the next potential (or actual) breaking version.
+Keeping these dependencies permissive increases the number of charms that can use your library
+without worrying too much about their other dependencies.

--- a/_docs/how-to/python-packages.md
+++ b/_docs/how-to/python-packages.md
@@ -25,6 +25,10 @@ and there is existing infrastructure and documentation supporting this pattern.
 However, if the relation library relies on any additional dependencies,
 it would still be better to make it a Python package.
 
+## Naming and namespacing your Python package
+
+
+
 ## How to distribute your Python package
 
 Distributing your package on PyPI has the most benefits.

--- a/_docs/index.md
+++ b/_docs/index.md
@@ -8,7 +8,9 @@ how-to/index
 reference/index
 ```
 
-This is the documentation website for Charm Tech's charm libraries (those that are distributed as Python packages).
+This is the Charm Tech team at Canonical's documentation website for charm libraries.
+It hosts the documentation for the team's charm libraries that are distributed as Python packages,
+as well as general documentation about charm libraries.
 
 You can also read our {ref}`guidance on distributing charm libraries as Python packages <how-to-python-package>`.
 

--- a/_docs/index.md
+++ b/_docs/index.md
@@ -8,18 +8,18 @@ how-to/index
 reference/index
 ```
 
-This is the documentation website for Charm Tech's charm library Python packages.
+This is the documentation website for Charm Tech's charm libraries (those that are distributed as Python packages).
 
-For guidance on distributing charm libraries as Python packages, check out the {ref}`how to <how-to-python-package>`.
+You can also read our {ref}`guidance on distributing charm libraries as Python packages <how-to-python-package>`.
 
 ## Pathops
 
 Pathops is a Python library providing
 a {doc}`pathlib <python:library/pathlib>`-like interface
-for [Juju](https://juju.is/) {ref}`Kubernetes Charms <juju:kubernetes-charm>`
+for [Juju](https://juju.is/) {ref}`Kubernetes charms <juju:kubernetes-charm>`
 to interact with files in their workload container.
 Interaction with remote files is performed via [ContainerPath](pathops.ContainerPath) objects.
 A [PathProtocol](pathops.PathProtocol) class is provided for use with type annotations,
 and a [LocalPath](pathops.LocalPath) class is provided which implements this protocol for local files.
 
-Available on [PyPI](https://pypi.org/project/charmlibs-pathops). Check out the reference documentation [here](pathops).
+Pathops is [available on PyPI](https://pypi.org/project/charmlibs-pathops). Read the [Pathops reference documentation](pathops).

--- a/_docs/index.md
+++ b/_docs/index.md
@@ -4,15 +4,22 @@
 :maxdepth: 3
 :hidden: false
 
+how-to/index
 reference/index
 ```
 
 This is the documentation website for Charm Tech's charm library Python packages.
 
-For more information, see also the [git repository](https://github.com/canonical/charmtech-charmlibs).
+For guidance on distributing charm libraries as Python packages, check out the {ref}`how to <how-to-python-packages>`.
 
 ## Pathops
 
-Pathops is a Python library providing a [pathlib](https://docs.python.org/3/library/pathlib.html)-like interface for [Juju](https://juju.is/) [Kubernetes Charms](https://documentation.ubuntu.com/juju/latest/reference/charm/#kubernetes) to interact with files in their workload container.
-Interaction with remote files is performed via ContainerPath objects.
-A PathProtocol class is provided for use with type annotations, and a LocalPath class is provided which implements this protocol for local files.
+Pathops is a Python library providing
+a {doc}`pathlib <python:library/pathlib>`-like interface
+for [Juju](https://juju.is/) {ref}`Kubernetes Charms <juju:kubernetes-charm>`
+to interact with files in their workload container.
+Interaction with remote files is performed via [ContainerPath](pathops.ContainerPath) objects.
+A [PathProtocol](pathops.PathProtocol) class is provided for use with type annotations,
+and a [LocalPath](pathops.LocalPath) class is provided which implements this protocol for local files.
+
+Available on [PyPI](https://pypi.org/project/charmlibs-pathops). Check out the reference documentation [here](pathops).

--- a/_docs/index.md
+++ b/_docs/index.md
@@ -18,8 +18,8 @@ Pathops is a Python library providing
 a {doc}`pathlib <python:library/pathlib>`-like interface
 for [Juju](https://juju.is/) {ref}`Kubernetes charms <juju:kubernetes-charm>`
 to interact with files in their workload container.
-Interaction with remote files is performed via [ContainerPath](pathops.ContainerPath) objects.
-A [PathProtocol](pathops.PathProtocol) class is provided for use with type annotations,
-and a [LocalPath](pathops.LocalPath) class is provided which implements this protocol for local files.
+Charms can use [ContainerPath](pathops.ContainerPath) to interact with files in the workload container,
+or [LocalPath](pathops.LocalPath) to interact with local files using the same API.
+Code designed to work for both cases can use [PathProtocol](pathops.PathProtocol) in type annotations.
 
 Pathops is [available on PyPI](https://pypi.org/project/charmlibs-pathops). Read the [Pathops reference documentation](pathops).

--- a/_docs/index.md
+++ b/_docs/index.md
@@ -10,7 +10,7 @@ reference/index
 
 This is the documentation website for Charm Tech's charm library Python packages.
 
-For guidance on distributing charm libraries as Python packages, check out the {ref}`how to <how-to-python-packages>`.
+For guidance on distributing charm libraries as Python packages, check out the {ref}`how to <how-to-python-package>`.
 
 ## Pathops
 

--- a/_docs/index.md
+++ b/_docs/index.md
@@ -12,11 +12,13 @@ This is the documentation website for Charm Tech's charm libraries (those that a
 
 You can also read our {ref}`guidance on distributing charm libraries as Python packages <how-to-python-package>`.
 
+If you're new charms, see {ref}`Juju | Charm <juju:charm>`.
+
 ## Pathops
 
 Pathops is a Python library providing
 a {doc}`pathlib <python:library/pathlib>`-like interface
-for [Juju](https://juju.is/) {ref}`Kubernetes charms <juju:kubernetes-charm>`
+for Kubernetes charms
 to interact with files in their workload container.
 Charms can use [ContainerPath](pathops.ContainerPath) to interact with files in the workload container,
 or [LocalPath](pathops.LocalPath) to interact with local files using the same API.


### PR DESCRIPTION
This PR adds a how-to guide for distributing charm libraries as Python packages. I'd greatly appreciate feedback on errors, gaps, and anything that would be better to cut completely or trim down. Docs build [here](https://canonical-charmlibs--36.com.readthedocs.build/).