### PR TITLE
feat: LocalPath also sets group (if not specified) based on user

### DIFF
--- a/justfile
+++ b/justfile
@@ -61,7 +61,7 @@ _coverage package test_subdir +flags='-rA':
     export COVERAGE_RCFILE=../pyproject.toml
     DATA_FILE=".report/coverage-$(basename {{test_subdir}})-{{python}}.db"
     uv run --active coverage run --data-file="$DATA_FILE" --source='src' \
-        -m pytest --tb=native -vv '{{flags}}' 'tests/{{test_subdir}}'
+        -m pytest --tb=native -vv {{flags}} 'tests/{{test_subdir}}'
     uv run --active coverage report --data-file="$DATA_FILE"
 
 [doc("Combine `coverage` reports, e.g. `just python=3.8 combine-coverage pathops`.")]
@@ -113,4 +113,4 @@ _juju package substrate +flags='-rA':
     uv pip install --editable './{{package}}'
     source .venv/bin/activate
     cd '{{package}}'
-    uv run --active pytest --tb=native -vv '{{flags}}' tests/integration/juju --substrate='{{substrate}}'
+    uv run --active pytest --tb=native -vv {{flags}} tests/integration/juju --substrate='{{substrate}}'

--- a/pathops/src/charmlibs/pathops/_container_path.py
+++ b/pathops/src/charmlibs/pathops/_container_path.py
@@ -504,13 +504,15 @@ class ContainerPath:
                 will be converted to :class:`bytes` in memory first.
             mode: The permissions to set on the file. Defaults to 0o644 (-rw-rw-r--).
             user: The name of the user to set for the file.
-            group: The name of the group to set for the file.
+                If ``group`` isn't provided, the user's default group is used.
+            group: The name of the group to set for the directory.
+                It is an error to provide ``group`` if ``user`` isn't provided.
 
         Returns: The number of bytes written.
 
         Raises:
             FileNotFoundError: if the parent directory does not exist.
-            LookupError: if the user or group is unknown.
+            LookupError: if the user or group is unknown, or a group is provided without a user.
             NotADirectoryError: if the parent exists as a non-directory file.
             PermissionError: if the Pebble user does not have permissions for the operation.
             PebbleConnectionError: if the remote Pebble client cannot be reached.
@@ -555,13 +557,15 @@ class ContainerPath:
                 raising any errors. Newlines are not modified on writing.
             mode: The permissions to set on the file. Defaults to 0o644 (-rw-rw-r--).
             user: The name of the user to set for the file.
-            group: The name of the group to set for the file.
+                If ``group`` isn't provided, the user's default group is used.
+            group: The name of the group to set for the directory.
+                It is an error to provide ``group`` if ``user`` isn't provided.
 
         Returns: The number of bytes written.
 
         Raises:
-            LookupError: if the user or group is unknown.
             FileNotFoundError: if the parent directory does not exist.
+            LookupError: if the user or group is unknown, or a group is provided without a user.
             NotADirectoryError: if the parent exists as a non-directory file.
             PermissionError: if the Pebble user does not have permissions for the operation.
             PebbleConnectionError: if the remote Pebble client cannot be reached.
@@ -594,12 +598,14 @@ class ContainerPath:
                 If ``False`` (default) and the directory already exists,
                 a :class:`FileExistsError` will be raised.
             user: The name of the user to set for the directory.
+                If ``group`` isn't provided, the user's default group is used.
             group: The name of the group to set for the directory.
+                It is an error to provide ``group`` if ``user`` isn't provided.
 
         Raises:
             FileExistsError: if the directory already exists and ``exist_ok`` is ``False``.
             FileNotFoundError: if the parent directory does not exist and ``parents`` is ``False``.
-            LookupError: if the user or group is unknown.
+            LookupError: if the user or group is unknown, or a group is provided without a user.
             NotADirectoryError: if the parent exists as a non-directory file.
             PermissionError: if the remote user does not have permissions for the operation.
             PebbleConnectionError: if the remote Pebble client cannot be reached.

--- a/pathops/src/charmlibs/pathops/_local_path.py
+++ b/pathops/src/charmlibs/pathops/_local_path.py
@@ -189,11 +189,10 @@ def _validate_user_and_group(user: str | None, group: str | None):
 
 
 def _chown_if_needed(path: pathlib.Path, user: str | int | None, group: str | int | None) -> None:
-    # shutil.chown is happy as long as either user or group is not None
-    # but the type checker doesn't like that, so we have to be more explicit
-    if user is not None and group is not None:
+    if user is not None:
+        if group is None:  # use the user's group, following Pebble
+            info = pwd.getpwnam(user) if isinstance(user, str) else pwd.getpwuid(user)
+            group = info.pw_gid
         shutil.chown(path, user=user, group=group)
-    elif user is not None:
-        shutil.chown(path, user=user)
     elif group is not None:
         shutil.chown(path, group=group)

--- a/pathops/src/charmlibs/pathops/_types.py
+++ b/pathops/src/charmlibs/pathops/_types.py
@@ -368,16 +368,18 @@ class PathProtocol(typing.Protocol):
         Args:
             data: The bytes to write, typically a :class:`bytes` object, but may also be a
                 :class:`bytearray` or :class:`memoryview`.
-            mode: The permissions to set on the file. Defaults to 0o644 (-rw-rw-r--).
-            user: The name of the user to set for the file.
-            group: The name of the group to set for the file.
+            mode: The permissions to set on the file. Defaults to 0o644 (-rw-r--r--).
+            user: The name of the user to set for the directory.
+                If ``group`` isn't provided, the user's default group is used.
+            group: The name of the group to set for the directory. For :class:`ContainerPath`,
+                it is an error to provide ``group`` if ``user`` isn't provided.
 
         Returns:
             The number of bytes written.
 
         Raises:
             FileNotFoundError: if the parent directory does not exist.
-            LookupError: if the user or group is unknown.
+            LookupError: if the user or group is unknown, or a group is provided without a user.
             NotADirectoryError: if the parent exists as a non-directory file.
             PermissionError: if the user does not have permissions for the operation.
             PebbleConnectionError: if the remote Pebble client cannot be reached.
@@ -401,16 +403,18 @@ class PathProtocol(typing.Protocol):
 
         Args:
             data: The string to write. Newlines are not modified on writing.
-            mode: The permissions to set on the file. Defaults to 0o644 (-rw-rw-r--).
-            user: The name of the user to set for the file.
-            group: The name of the group to set for the file.
+            mode: The permissions to set on the file. Defaults to 0o644 (-rw-r--r--).
+            user: The name of the user to set for the directory.
+                If ``group`` isn't provided, the user's default group is used.
+            group: The name of the group to set for the directory. For :class:`ContainerPath`,
+                it is an error to provide ``group`` if ``user`` isn't provided.
 
         Returns:
             The number of bytes written.
 
         Raises:
             FileNotFoundError: if the parent directory does not exist.
-            LookupError: if the user or group is unknown.
+            LookupError: if the user or group is unknown, or a group is provided without a user.
             NotADirectoryError: if the parent exists as a non-directory file.
             PermissionError: if the user does not have permissions for the operation.
             UnicodeError: if the provided data is not valid UTF-8.
@@ -443,12 +447,14 @@ class PathProtocol(typing.Protocol):
                 If ``False`` (default) and the directory already exists,
                 a :class:`FileExistsError` will be raised.
             user: The name of the user to set for the directory.
-            group: The name of the group to set for the directory.
+                If ``group`` isn't provided, the user's default group is used.
+            group: The name of the group to set for the directory. For :class:`ContainerPath`,
+                it is an error to provide ``group`` if ``user`` isn't provided.
 
         Raises:
             FileExistsError: if the directory already exists and ``exist_ok`` is ``False``.
             FileNotFoundError: if the parent directory does not exist and ``parents`` is ``False``.
-            LookupError: if the user or group is unknown.
+            LookupError: if the user or group is unknown, or a group is provided without a user.
             NotADirectoryError: if the parent exists as a non-directory file.
             PermissionError: if the local user does not have permissions for the operation.
             PebbleConnectionError: if the remote Pebble client cannot be reached.

--- a/pathops/tests/integration/juju/charms/kubernetes/charmcraft.yaml
+++ b/pathops/tests/integration/juju/charms/kubernetes/charmcraft.yaml
@@ -35,3 +35,11 @@ actions:
       n-temp-files:
         type: integer
         description: The number of files to create in a tempdir before calling iterdir on it.
+  chown:
+    params:
+      method:
+        type: string
+      user:
+        type: string
+      group:
+        type: string

--- a/pathops/tests/integration/juju/charms/kubernetes/src/charm.py
+++ b/pathops/tests/integration/juju/charms/kubernetes/src/charm.py
@@ -15,8 +15,11 @@
 
 """Charm the application."""
 
+from __future__ import annotations
+
 import logging
 import pathlib
+import typing
 
 import common
 import ops
@@ -25,6 +28,9 @@ import ops
 #       after next pyright release fixes:
 #       https://github.com/microsoft/pyright/issues/10203
 import charmlibs.pathops as pathops
+
+if typing.TYPE_CHECKING:
+    from typing import Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +53,9 @@ class Charm(common.Charm):
     def remove_path(self, path: pathops.PathProtocol, recursive: bool = False) -> None:
         assert isinstance(path, pathops.ContainerPath)
         self.container.remove_path(str(path), recursive=recursive)
+
+    def exec(self, cmd: Sequence[str]) -> None:
+        self.container.exec(list(cmd))
 
 
 if __name__ == '__main__':  # pragma: nocover

--- a/pathops/tests/integration/juju/charms/kubernetes/src/charm.py
+++ b/pathops/tests/integration/juju/charms/kubernetes/src/charm.py
@@ -54,8 +54,13 @@ class Charm(common.Charm):
         if path.exists():
             self.container.remove_path(str(path), recursive=recursive)
 
-    def exec(self, cmd: Sequence[str]) -> None:
-        self.container.exec(list(cmd)).wait()
+    def exec(self, cmd: Sequence[str]) -> int:
+        process = self.container.exec(list(cmd))
+        try:
+            process.wait()
+            return 0
+        except ops.pebble.ExecError as e:
+            return e.exit_code
 
 
 if __name__ == '__main__':  # pragma: nocover

--- a/pathops/tests/integration/juju/charms/kubernetes/src/charm.py
+++ b/pathops/tests/integration/juju/charms/kubernetes/src/charm.py
@@ -55,7 +55,7 @@ class Charm(common.Charm):
         self.container.remove_path(str(path), recursive=recursive)
 
     def exec(self, cmd: Sequence[str]) -> None:
-        self.container.exec(list(cmd))
+        self.container.exec(list(cmd)).wait()
 
 
 if __name__ == '__main__':  # pragma: nocover

--- a/pathops/tests/integration/juju/charms/kubernetes/src/charm.py
+++ b/pathops/tests/integration/juju/charms/kubernetes/src/charm.py
@@ -51,7 +51,8 @@ class Charm(common.Charm):
 
     def remove_path(self, path: pathops.PathProtocol, recursive: bool = False) -> None:
         assert isinstance(path, pathops.ContainerPath)
-        self.container.remove_path(str(path), recursive=recursive)
+        if path.exists():
+            self.container.remove_path(str(path), recursive=recursive)
 
     def exec(self, cmd: Sequence[str]) -> None:
         self.container.exec(list(cmd)).wait()

--- a/pathops/tests/integration/juju/charms/kubernetes/src/charm.py
+++ b/pathops/tests/integration/juju/charms/kubernetes/src/charm.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import logging
-import pathlib
 import typing
 
 import common
@@ -44,7 +43,7 @@ class Charm(common.Charm):
         super().__init__(framework)
         framework.observe(self.on[CONTAINER].pebble_ready, self._on_pebble_ready)
         self.container = self.unit.get_container(CONTAINER)
-        self.root = pathops.ContainerPath(pathlib.Path('/', 'tmp'), container=self.container)
+        self.root = pathops.ContainerPath('/', 'tmp', container=self.container)
 
     def _on_pebble_ready(self, event: ops.PebbleReadyEvent):
         """Handle pebble-ready event."""

--- a/pathops/tests/integration/juju/charms/kubernetes/src/charm.py
+++ b/pathops/tests/integration/juju/charms/kubernetes/src/charm.py
@@ -59,7 +59,7 @@ class Charm(common.Charm):
         try:
             process.wait()
             return 0
-        except ops.pebble.ExecError as e:
+        except ops.pebble.ExecError[str] as e:
             return e.exit_code
 
 

--- a/pathops/tests/integration/juju/charms/kubernetes/src/common.py
+++ b/pathops/tests/integration/juju/charms/kubernetes/src/common.py
@@ -109,7 +109,7 @@ class Charm(ops.CharmBase):
 
     def addusers(self) -> None:
         for user in self.users:
-            self.exec(['adduser', user])
+            self.exec(['adduser', '--disabled-password', '--comment', '', user])
 
     def rmusers(self) -> None:
         for user in self.users:

--- a/pathops/tests/integration/juju/charms/kubernetes/src/common.py
+++ b/pathops/tests/integration/juju/charms/kubernetes/src/common.py
@@ -102,7 +102,6 @@ class Charm(ops.CharmBase):
             event.set_results(results)
         except Exception as e:
             event.fail(f'Exception: {e!r}')
-            return
         finally:
             self.remove_path(path)
             self.rmusers()

--- a/pathops/tests/integration/juju/charms/kubernetes/src/common.py
+++ b/pathops/tests/integration/juju/charms/kubernetes/src/common.py
@@ -83,9 +83,9 @@ class Charm(ops.CharmBase):
         if path.exists():
             event.fail('File already exists.')
             return
+        method: str = event.params['method']
         user: str | None = event.params['user'] or None
         group: str | None = event.params['group'] or None
-        method: str = event.params['method']
         temp_user = 'temp-user'
         self.add_user(temp_user)
         try:

--- a/pathops/tests/integration/juju/charms/kubernetes/src/common.py
+++ b/pathops/tests/integration/juju/charms/kubernetes/src/common.py
@@ -109,7 +109,13 @@ class Charm(ops.CharmBase):
 
     def addusers(self) -> None:
         for user in self.users:
-            self.exec(['adduser', '--disabled-password', '--comment', '', user])
+            self.exec([
+                'adduser',
+                '--disabled-password',
+                '--no-create-home',
+                '--comment=""',  # don't ask for info interactively
+                user,
+            ])
 
     def rmusers(self) -> None:
         for user in self.users:

--- a/pathops/tests/integration/juju/charms/kubernetes/src/common.py
+++ b/pathops/tests/integration/juju/charms/kubernetes/src/common.py
@@ -87,7 +87,7 @@ class Charm(ops.CharmBase):
         group: str | None = event.params['group'] or None
         method: str = event.params['method']
         temp_user = 'temp-user'
-        self.adduser(temp_user)
+        self.add_user(temp_user)
         try:
             if method == 'mkdir':
                 path.mkdir(user=user, group=group)
@@ -96,24 +96,22 @@ class Charm(ops.CharmBase):
             elif method == 'write_text':
                 path.write_text('', user=user, group=group)
             else:
-                event.fail(f'Unknown method: {method!r}')
-                return
-            results = {'user': path.owner(), 'group': path.group()}
-            event.set_results(results)
+                raise ValueError(f'Unknown method: {method!r}')
+            event.set_results({'user': path.owner(), 'group': path.group()})
         except Exception as e:
             event.fail(f'Exception: {e!r}')
         finally:
             self.remove_path(path)
-            self.rmuser(temp_user)
+            self.remove_user(temp_user)
 
-    def adduser(self, user: str) -> None:
+    def add_user(self, user: str) -> None:
         retcode = self.exec(['useradd', user])
         assert retcode in (
             0,  # success
             9,  # already exists
         )
 
-    def rmuser(self, user: str) -> None:
+    def remove_user(self, user: str) -> None:
         retcode = self.exec(['userdel', '--remove', user])
         assert retcode in (
             0,  # success

--- a/pathops/tests/integration/juju/charms/kubernetes/src/common.py
+++ b/pathops/tests/integration/juju/charms/kubernetes/src/common.py
@@ -56,7 +56,7 @@ class Charm(ops.CharmBase):
     def remove_path(self, path: pathops.PathProtocol, recursive: bool = False) -> None:
         raise NotImplementedError()
 
-    def exec(self, cmd: Sequence[str]) -> None:
+    def exec(self, cmd: Sequence[str]) -> int:
         raise NotImplementedError()
 
     def _on_ensure_contents(self, event: ops.ActionEvent) -> None:
@@ -109,11 +109,16 @@ class Charm(ops.CharmBase):
 
     def addusers(self) -> None:
         for user in self.users:
-            self.exec([
-                'useradd',
-                user,
-            ])
+            retcode = self.exec(['useradd', user])
+            assert retcode in (
+                0,  # success
+                9,  # already exists
+            )
 
     def rmusers(self) -> None:
         for user in self.users:
-            self.exec(['userdel', '--remove', user])
+            retcode = self.exec(['userdel', '--remove', user])
+            assert retcode in (
+                0,  # success
+                6,  # doesn't exist
+            )

--- a/pathops/tests/integration/juju/charms/kubernetes/src/common.py
+++ b/pathops/tests/integration/juju/charms/kubernetes/src/common.py
@@ -102,7 +102,6 @@ class Charm(ops.CharmBase):
             event.fail(f'Exception: {e!r}')
             return
         results = {'user': path.owner(), 'group': path.group()}
-        logger.error(results)
         self.remove_path(path)
         self.rmusers()
         event.set_results(results)
@@ -110,14 +109,11 @@ class Charm(ops.CharmBase):
     def addusers(self) -> None:
         for user in self.users:
             self.exec([
-                'adduser',
-                '--disabled-password',
-                '--no-create-home',
-                '--comment=""',  # don't ask for info interactively
+                'useradd',
                 user,
             ])
 
     def rmusers(self) -> None:
         for user in self.users:
-            self.exec(['deluser', user])
-            self.exec(['delgroup', user])
+            self.exec(['userdel', '--remove', user])
+            self.exec(['groupdel', user])

--- a/pathops/tests/integration/juju/charms/kubernetes/src/common.py
+++ b/pathops/tests/integration/juju/charms/kubernetes/src/common.py
@@ -45,7 +45,6 @@ class Charm(ops.CharmBase):
     """
 
     root: pathops.PathProtocol
-    users = ('temp-user',)
 
     def __init__(self, framework: ops.Framework):
         super().__init__(framework)
@@ -87,7 +86,8 @@ class Charm(ops.CharmBase):
         user: str | None = event.params['user'] or None
         group: str | None = event.params['group'] or None
         method: str = event.params['method']
-        self.addusers()
+        temp_user = 'temp-user'
+        self.adduser(temp_user)
         try:
             if method == 'mkdir':
                 path.mkdir(user=user, group=group)
@@ -104,20 +104,18 @@ class Charm(ops.CharmBase):
             event.fail(f'Exception: {e!r}')
         finally:
             self.remove_path(path)
-            self.rmusers()
+            self.rmuser(temp_user)
 
-    def addusers(self) -> None:
-        for user in self.users:
-            retcode = self.exec(['useradd', user])
-            assert retcode in (
-                0,  # success
-                9,  # already exists
-            )
+    def adduser(self, user: str) -> None:
+        retcode = self.exec(['useradd', user])
+        assert retcode in (
+            0,  # success
+            9,  # already exists
+        )
 
-    def rmusers(self) -> None:
-        for user in self.users:
-            retcode = self.exec(['userdel', '--remove', user])
-            assert retcode in (
-                0,  # success
-                6,  # doesn't exist
-            )
+    def rmuser(self, user: str) -> None:
+        retcode = self.exec(['userdel', '--remove', user])
+        assert retcode in (
+            0,  # success
+            6,  # doesn't exist
+        )

--- a/pathops/tests/integration/juju/charms/kubernetes/src/common.py
+++ b/pathops/tests/integration/juju/charms/kubernetes/src/common.py
@@ -84,7 +84,7 @@ class Charm(ops.CharmBase):
         except Exception as e:
             event.fail(f'Exception: {e!r}')
             return
-        results = {'user': path.owner, 'group': path.group}
+        results = {'user': path.owner(), 'group': path.group()}
         logger.error(results)
         self.remove_path(path)
         event.set_results(results)

--- a/pathops/tests/integration/juju/charms/kubernetes/src/common.py
+++ b/pathops/tests/integration/juju/charms/kubernetes/src/common.py
@@ -61,7 +61,7 @@ class Charm(ops.CharmBase):
     def _on_chown(self, event: ops.ActionEvent) -> None:
         path = self.root / 'unique-temp-name'
         if path.exists():
-            event.fail("File already exists.")
+            event.fail('File already exists.')
             return
         user: str | None = event.params['user'] or None
         group: str | None = event.params['group'] or None

--- a/pathops/tests/integration/juju/charms/kubernetes/src/common.py
+++ b/pathops/tests/integration/juju/charms/kubernetes/src/common.py
@@ -30,6 +30,7 @@ import charmlibs.pathops as pathops
 
 logger = logging.getLogger(__name__)
 
+
 class Charm(ops.CharmBase):
     root: pathops.PathProtocol
 

--- a/pathops/tests/integration/juju/charms/kubernetes/src/common.py
+++ b/pathops/tests/integration/juju/charms/kubernetes/src/common.py
@@ -38,6 +38,7 @@ class Charm(ops.CharmBase):
         super().__init__(framework)
         framework.observe(self.on['ensure-contents'].action, self._on_ensure_contents)
         framework.observe(self.on['iterdir'].action, self._on_iterdir)
+        framework.observe(self.on['chown'].action, self._on_chown)
 
     def remove_path(self, path: pathops.PathProtocol, recursive: bool = False) -> None:
         raise NotImplementedError()

--- a/pathops/tests/integration/juju/charms/kubernetes/src/common.py
+++ b/pathops/tests/integration/juju/charms/kubernetes/src/common.py
@@ -19,6 +19,8 @@ The contents of kubernetes/src/common.py and machine/src/common.py should be ide
 
 from __future__ import annotations
 
+import logging
+
 import ops
 
 # TODO: switch to recommended form `from charmlibs import pathops`
@@ -26,6 +28,7 @@ import ops
 #       https://github.com/microsoft/pyright/issues/10203
 import charmlibs.pathops as pathops
 
+logger = logging.getLogger(__name__)
 
 class Charm(ops.CharmBase):
     root: pathops.PathProtocol
@@ -80,5 +83,6 @@ class Charm(ops.CharmBase):
             event.fail(f'Exception: {e!r}')
             return
         results = {'user': path.owner, 'group': path.group}
+        logger.error(results)
         self.remove_path(path)
         event.set_results(results)

--- a/pathops/tests/integration/juju/charms/kubernetes/src/common.py
+++ b/pathops/tests/integration/juju/charms/kubernetes/src/common.py
@@ -79,6 +79,6 @@ class Charm(ops.CharmBase):
         except Exception as e:
             event.fail(f'Exception: {e!r}')
             return
-        results = {'owner': path.owner, 'group': path.group}
+        results = {'user': path.owner, 'group': path.group}
         self.remove_path(path)
         event.set_results(results)

--- a/pathops/tests/integration/juju/charms/machine/charmcraft.yaml
+++ b/pathops/tests/integration/juju/charms/machine/charmcraft.yaml
@@ -25,3 +25,11 @@ actions:
       n-temp-files:
         type: integer
         description: The number of files to create in a tempdir before calling iterdir on it.
+  chown:
+    params:
+      method:
+        type: string
+      user:
+        type: string
+      group:
+        type: string

--- a/pathops/tests/integration/juju/charms/machine/src/charm.py
+++ b/pathops/tests/integration/juju/charms/machine/src/charm.py
@@ -50,6 +50,8 @@ class Charm(common.Charm):
 
     def remove_path(self, path: pathops.PathProtocol, recursive: bool = False) -> None:
         assert isinstance(path, pathops.LocalPath)
+        if not path.exists():
+            return
         if not path.is_dir():
             return path.unlink()
         if not recursive:

--- a/pathops/tests/integration/juju/charms/machine/src/charm.py
+++ b/pathops/tests/integration/juju/charms/machine/src/charm.py
@@ -58,8 +58,9 @@ class Charm(common.Charm):
             return path.rmdir()
         shutil.rmtree(path)
 
-    def exec(self, cmd: Sequence[str]) -> None:
-        subprocess.run(cmd, check=True)
+    def exec(self, cmd: Sequence[str]) -> int:
+        process = subprocess.run(cmd)
+        return process.returncode
 
 
 if __name__ == '__main__':  # pragma: nocover

--- a/pathops/tests/integration/juju/charms/machine/src/charm.py
+++ b/pathops/tests/integration/juju/charms/machine/src/charm.py
@@ -15,8 +15,12 @@
 
 """Charm the application."""
 
+from __future__ import annotations
+
 import logging
 import shutil
+import subprocess
+import typing
 
 import common
 import ops
@@ -25,6 +29,9 @@ import ops
 #       after next pyright release fixes:
 #       https://github.com/microsoft/pyright/issues/10203
 import charmlibs.pathops as pathops
+
+if typing.TYPE_CHECKING:
+    from typing import Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +55,9 @@ class Charm(common.Charm):
         if not recursive:
             return path.rmdir()
         shutil.rmtree(path)
+
+    def exec(self, cmd: Sequence[str]) -> None:
+        subprocess.run(cmd, check=True)
 
 
 if __name__ == '__main__':  # pragma: nocover

--- a/pathops/tests/integration/juju/charms/machine/src/common.py
+++ b/pathops/tests/integration/juju/charms/machine/src/common.py
@@ -109,7 +109,7 @@ class Charm(ops.CharmBase):
 
     def addusers(self) -> None:
         for user in self.users:
-            self.exec(['adduser', user])
+            self.exec(['adduser', '--disabled-password', '--comment', '', user])
 
     def rmusers(self) -> None:
         for user in self.users:

--- a/pathops/tests/integration/juju/charms/machine/src/common.py
+++ b/pathops/tests/integration/juju/charms/machine/src/common.py
@@ -102,7 +102,6 @@ class Charm(ops.CharmBase):
             event.set_results(results)
         except Exception as e:
             event.fail(f'Exception: {e!r}')
-            return
         finally:
             self.remove_path(path)
             self.rmusers()

--- a/pathops/tests/integration/juju/charms/machine/src/common.py
+++ b/pathops/tests/integration/juju/charms/machine/src/common.py
@@ -109,7 +109,13 @@ class Charm(ops.CharmBase):
 
     def addusers(self) -> None:
         for user in self.users:
-            self.exec(['adduser', '--disabled-password', '--comment', '', user])
+            self.exec([
+                'adduser',
+                '--disabled-password',
+                '--no-create-home',
+                '--comment=""',  # don't ask for info interactively
+                user,
+            ])
 
     def rmusers(self) -> None:
         for user in self.users:

--- a/pathops/tests/integration/juju/charms/machine/src/common.py
+++ b/pathops/tests/integration/juju/charms/machine/src/common.py
@@ -83,11 +83,11 @@ class Charm(ops.CharmBase):
         if path.exists():
             event.fail('File already exists.')
             return
+        method: str = event.params['method']
         user: str | None = event.params['user'] or None
         group: str | None = event.params['group'] or None
-        method: str = event.params['method']
         temp_user = 'temp-user'
-        self.adduser(temp_user)
+        self.add_user(temp_user)
         try:
             if method == 'mkdir':
                 path.mkdir(user=user, group=group)
@@ -96,24 +96,22 @@ class Charm(ops.CharmBase):
             elif method == 'write_text':
                 path.write_text('', user=user, group=group)
             else:
-                event.fail(f'Unknown method: {method!r}')
-                return
-            results = {'user': path.owner(), 'group': path.group()}
-            event.set_results(results)
+                raise ValueError(f'Unknown method: {method!r}')
+            event.set_results({'user': path.owner(), 'group': path.group()})
         except Exception as e:
             event.fail(f'Exception: {e!r}')
         finally:
             self.remove_path(path)
-            self.rmuser(temp_user)
+            self.remove_user(temp_user)
 
-    def adduser(self, user: str) -> None:
+    def add_user(self, user: str) -> None:
         retcode = self.exec(['useradd', user])
         assert retcode in (
             0,  # success
             9,  # already exists
         )
 
-    def rmuser(self, user: str) -> None:
+    def remove_user(self, user: str) -> None:
         retcode = self.exec(['userdel', '--remove', user])
         assert retcode in (
             0,  # success

--- a/pathops/tests/integration/juju/charms/machine/src/common.py
+++ b/pathops/tests/integration/juju/charms/machine/src/common.py
@@ -56,7 +56,7 @@ class Charm(ops.CharmBase):
     def remove_path(self, path: pathops.PathProtocol, recursive: bool = False) -> None:
         raise NotImplementedError()
 
-    def exec(self, cmd: Sequence[str]) -> None:
+    def exec(self, cmd: Sequence[str]) -> int:
         raise NotImplementedError()
 
     def _on_ensure_contents(self, event: ops.ActionEvent) -> None:
@@ -109,11 +109,16 @@ class Charm(ops.CharmBase):
 
     def addusers(self) -> None:
         for user in self.users:
-            self.exec([
-                'useradd',
-                user,
-            ])
+            retcode = self.exec(['useradd', user])
+            assert retcode in (
+                0,  # success
+                9,  # already exists
+            )
 
     def rmusers(self) -> None:
         for user in self.users:
-            self.exec(['userdel', '--remove', user])
+            retcode = self.exec(['userdel', '--remove', user])
+            assert retcode in (
+                0,  # success
+                6,  # doesn't exist
+            )

--- a/pathops/tests/integration/juju/charms/machine/src/common.py
+++ b/pathops/tests/integration/juju/charms/machine/src/common.py
@@ -102,7 +102,6 @@ class Charm(ops.CharmBase):
             event.fail(f'Exception: {e!r}')
             return
         results = {'user': path.owner(), 'group': path.group()}
-        logger.error(results)
         self.remove_path(path)
         self.rmusers()
         event.set_results(results)
@@ -110,14 +109,11 @@ class Charm(ops.CharmBase):
     def addusers(self) -> None:
         for user in self.users:
             self.exec([
-                'adduser',
-                '--disabled-password',
-                '--no-create-home',
-                '--comment=""',  # don't ask for info interactively
+                'useradd',
                 user,
             ])
 
     def rmusers(self) -> None:
         for user in self.users:
-            self.exec(['deluser', user])
-            self.exec(['delgroup', user])
+            self.exec(['userdel', '--remove', user])
+            self.exec(['groupdel', user])

--- a/pathops/tests/integration/juju/charms/machine/src/common.py
+++ b/pathops/tests/integration/juju/charms/machine/src/common.py
@@ -45,7 +45,6 @@ class Charm(ops.CharmBase):
     """
 
     root: pathops.PathProtocol
-    users = ('temp-user',)
 
     def __init__(self, framework: ops.Framework):
         super().__init__(framework)
@@ -87,7 +86,8 @@ class Charm(ops.CharmBase):
         user: str | None = event.params['user'] or None
         group: str | None = event.params['group'] or None
         method: str = event.params['method']
-        self.addusers()
+        temp_user = 'temp-user'
+        self.adduser(temp_user)
         try:
             if method == 'mkdir':
                 path.mkdir(user=user, group=group)
@@ -104,20 +104,18 @@ class Charm(ops.CharmBase):
             event.fail(f'Exception: {e!r}')
         finally:
             self.remove_path(path)
-            self.rmusers()
+            self.rmuser(temp_user)
 
-    def addusers(self) -> None:
-        for user in self.users:
-            retcode = self.exec(['useradd', user])
-            assert retcode in (
-                0,  # success
-                9,  # already exists
-            )
+    def adduser(self, user: str) -> None:
+        retcode = self.exec(['useradd', user])
+        assert retcode in (
+            0,  # success
+            9,  # already exists
+        )
 
-    def rmusers(self) -> None:
-        for user in self.users:
-            retcode = self.exec(['userdel', '--remove', user])
-            assert retcode in (
-                0,  # success
-                6,  # doesn't exist
-            )
+    def rmuser(self, user: str) -> None:
+        retcode = self.exec(['userdel', '--remove', user])
+        assert retcode in (
+            0,  # success
+            6,  # doesn't exist
+        )

--- a/pathops/tests/integration/juju/charms/machine/src/common.py
+++ b/pathops/tests/integration/juju/charms/machine/src/common.py
@@ -84,7 +84,7 @@ class Charm(ops.CharmBase):
         except Exception as e:
             event.fail(f'Exception: {e!r}')
             return
-        results = {'user': path.owner, 'group': path.group}
+        results = {'user': path.owner(), 'group': path.group()}
         logger.error(results)
         self.remove_path(path)
         event.set_results(results)

--- a/pathops/tests/integration/juju/charms/machine/src/common.py
+++ b/pathops/tests/integration/juju/charms/machine/src/common.py
@@ -61,7 +61,7 @@ class Charm(ops.CharmBase):
     def _on_chown(self, event: ops.ActionEvent) -> None:
         path = self.root / 'unique-temp-name'
         if path.exists():
-            event.fail("File already exists.")
+            event.fail('File already exists.')
             return
         user: str | None = event.params['user'] or None
         group: str | None = event.params['group'] or None

--- a/pathops/tests/integration/juju/charms/machine/src/common.py
+++ b/pathops/tests/integration/juju/charms/machine/src/common.py
@@ -30,6 +30,7 @@ import charmlibs.pathops as pathops
 
 logger = logging.getLogger(__name__)
 
+
 class Charm(ops.CharmBase):
     root: pathops.PathProtocol
 

--- a/pathops/tests/integration/juju/charms/machine/src/common.py
+++ b/pathops/tests/integration/juju/charms/machine/src/common.py
@@ -38,6 +38,7 @@ class Charm(ops.CharmBase):
         super().__init__(framework)
         framework.observe(self.on['ensure-contents'].action, self._on_ensure_contents)
         framework.observe(self.on['iterdir'].action, self._on_iterdir)
+        framework.observe(self.on['chown'].action, self._on_chown)
 
     def remove_path(self, path: pathops.PathProtocol, recursive: bool = False) -> None:
         raise NotImplementedError()

--- a/pathops/tests/integration/juju/charms/machine/src/common.py
+++ b/pathops/tests/integration/juju/charms/machine/src/common.py
@@ -19,6 +19,8 @@ The contents of kubernetes/src/common.py and machine/src/common.py should be ide
 
 from __future__ import annotations
 
+import logging
+
 import ops
 
 # TODO: switch to recommended form `from charmlibs import pathops`
@@ -26,6 +28,7 @@ import ops
 #       https://github.com/microsoft/pyright/issues/10203
 import charmlibs.pathops as pathops
 
+logger = logging.getLogger(__name__)
 
 class Charm(ops.CharmBase):
     root: pathops.PathProtocol
@@ -80,5 +83,6 @@ class Charm(ops.CharmBase):
             event.fail(f'Exception: {e!r}')
             return
         results = {'user': path.owner, 'group': path.group}
+        logger.error(results)
         self.remove_path(path)
         event.set_results(results)

--- a/pathops/tests/integration/juju/charms/machine/src/common.py
+++ b/pathops/tests/integration/juju/charms/machine/src/common.py
@@ -79,6 +79,6 @@ class Charm(ops.CharmBase):
         except Exception as e:
             event.fail(f'Exception: {e!r}')
             return
-        results = {'owner': path.owner, 'group': path.group}
+        results = {'user': path.owner, 'group': path.group}
         self.remove_path(path)
         event.set_results(results)

--- a/pathops/tests/integration/juju/test_pathops.py
+++ b/pathops/tests/integration/juju/test_pathops.py
@@ -67,7 +67,7 @@ def test_chown(juju: jubilant.Juju, charm: str, method: str, user: str | None, g
     except jubilant.TaskError as e:
         if charm == 'kubernetes' and user is None and group is not None:
             # we expect the group only case to fail unless Pebble is updated to handle it
-            prefix = 'Exception :'
+            prefix = 'Exception: '
             assert e.task.message.startswith(prefix)
             msg = e.task.message[len(prefix) :]
             assert msg.startswith('LookupError')

--- a/pathops/tests/integration/juju/test_pathops.py
+++ b/pathops/tests/integration/juju/test_pathops.py
@@ -73,7 +73,6 @@ def test_chown(juju: jubilant.Juju, charm: str, method: str, user: str | None, g
             assert msg.startswith('LookupError')
             return
         raise
-    print(result)
     expected_user = user if user is not None else 'root'
     expected_group = group if group is not None else expected_user
     assert result.results['user'] == expected_user

--- a/pathops/tests/integration/juju/test_pathops.py
+++ b/pathops/tests/integration/juju/test_pathops.py
@@ -17,12 +17,9 @@
 from __future__ import annotations
 
 import ast
-import typing
 
+import jubilant
 import pytest
-
-if typing.TYPE_CHECKING:
-    import jubilant
 
 
 def test_deploy(juju: jubilant.Juju, charm: str):

--- a/pathops/tests/integration/juju/test_pathops.py
+++ b/pathops/tests/integration/juju/test_pathops.py
@@ -50,23 +50,34 @@ def test_iterdir(juju: jubilant.Juju, charm: str):
     (
         (None, None),
         ('root', None),
+        ('temp-user', None),
         (None, 'root'),
+        (None, 'temp-user'),
         ('root', 'root'),
+        ('root', 'temp-user'),
+        ('temp-user', 'root'),
+        ('temp-user', 'temp-user'),
     ),
 )
 @pytest.mark.parametrize('method', ['mkdir', 'write_bytes', 'write_text'])
 def test_chown(juju: jubilant.Juju, charm: str, method: str, user: str | None, group: str | None):
-    print('juju run')
-    result = juju.run(
-        f'{charm}/0',
-        'chown',
-        params={'method': method, 'user': user or '', 'group': group or ''},
-    )
+    try:
+        result = juju.run(
+            f'{charm}/0',
+            'chown',
+            params={'method': method, 'user': user or '', 'group': group or ''},
+        )
+    except jubilant.TaskError as e:
+        if charm == 'kubernetes' and user is None and group is not None:
+            # we expect the group only case to fail unless Pebble is updated to handle it
+            prefix = 'Exception :'
+            assert e.task.message.startswith(prefix)
+            msg = e.task.message.removeprefix(prefix)
+            assert msg.startswith('LookupError')
+            return
+        raise
     print(result)
-    print(result.results)
-    if user is not None:
-        print('asserting on user')
-        assert result.results['user'] == user
-    if group is not None:
-        print('asserting on group')
-        assert result.results['group'] == group
+    expected_user = user if user is not None else 'root'
+    expected_group = group if group is not None else user
+    assert result.results['user'] == expected_user
+    assert result.results['group'] == expected_group

--- a/pathops/tests/integration/juju/test_pathops.py
+++ b/pathops/tests/integration/juju/test_pathops.py
@@ -75,6 +75,6 @@ def test_chown(juju: jubilant.Juju, charm: str, method: str, user: str | None, g
         raise
     print(result)
     expected_user = user if user is not None else 'root'
-    expected_group = group if group is not None else user
+    expected_group = group if group is not None else expected_user
     assert result.results['user'] == expected_user
     assert result.results['group'] == expected_group

--- a/pathops/tests/integration/juju/test_pathops.py
+++ b/pathops/tests/integration/juju/test_pathops.py
@@ -58,15 +58,12 @@ def test_iterdir(juju: jubilant.Juju, charm: str):
 )
 @pytest.mark.parametrize('method', ['mkdir', 'write_bytes', 'write_text'])
 def test_chown(juju: jubilant.Juju, charm: str, method: str, user: str | None, group: str | None):
+    params = {'method': method, 'user': user or '', 'group': group or ''}
     try:
-        result = juju.run(
-            f'{charm}/0',
-            'chown',
-            params={'method': method, 'user': user or '', 'group': group or ''},
-        )
+        result = juju.run(f'{charm}/0', 'chown', params=params)
     except jubilant.TaskError as e:
         if charm == 'kubernetes' and user is None and group is not None:
-            # we expect the group only case to fail unless Pebble is updated to handle it
+            # we expect the group-only case to fail (unless Pebble is updated to handle it)
             prefix = 'Exception: '
             assert e.task.message.startswith(prefix)
             msg = e.task.message[len(prefix) :]

--- a/pathops/tests/integration/juju/test_pathops.py
+++ b/pathops/tests/integration/juju/test_pathops.py
@@ -69,7 +69,7 @@ def test_chown(juju: jubilant.Juju, charm: str, method: str, user: str | None, g
             # we expect the group only case to fail unless Pebble is updated to handle it
             prefix = 'Exception :'
             assert e.task.message.startswith(prefix)
-            msg = e.task.message.removeprefix(prefix)
+            msg = e.task.message[len(prefix) :]
             assert msg.startswith('LookupError')
             return
         raise

--- a/pathops/tests/integration/juju/test_pathops.py
+++ b/pathops/tests/integration/juju/test_pathops.py
@@ -56,12 +56,17 @@ def test_iterdir(juju: jubilant.Juju, charm: str):
 )
 @pytest.mark.parametrize('method', ['mkdir', 'write_bytes', 'write_text'])
 def test_chown(juju: jubilant.Juju, charm: str, method: str, user: str | None, group: str | None):
+    print('juju run')
     result = juju.run(
         f'{charm}/0',
         'chown',
         params={'method': method, 'user': user or '', 'group': group or ''},
     )
+    print(result)
+    print(result.results)
     if user is not None:
+        print('asserting on user')
         assert result.results['user'] == user
     if group is not None:
+        print('asserting on group')
         assert result.results['group'] == group

--- a/pathops/tests/integration/juju/test_pathops.py
+++ b/pathops/tests/integration/juju/test_pathops.py
@@ -52,7 +52,7 @@ def test_iterdir(juju: jubilant.Juju, charm: str):
         ('root', None),
         (None, 'root'),
         ('root', 'root'),
-    )
+    ),
 )
 @pytest.mark.parametrize('method', ['mkdir', 'write_bytes', 'write_text'])
 def test_chown(juju: jubilant.Juju, charm: str, method: str, user: str | None, group: str | None):

--- a/pathops/tests/integration/juju/test_pathops.py
+++ b/pathops/tests/integration/juju/test_pathops.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import ast
 import typing
 
+import pytest
+
 if typing.TYPE_CHECKING:
     import jubilant
 
@@ -41,3 +43,25 @@ def test_iterdir(juju: jubilant.Juju, charm: str):
     result = juju.run(f'{charm}/0', 'iterdir', params={'n-temp-files': n})
     files = ast.literal_eval(result.results['files'])
     assert len(files) == n
+
+
+@pytest.mark.parametrize(
+    ('user', 'group'),
+    (
+        (None, None),
+        ('root', None),
+        (None, 'root'),
+        ('root', 'root'),
+    )
+)
+@pytest.mark.parametrize('method', ['mkdir', 'write_bytes', 'write_text'])
+def test_chown(juju: jubilant.Juju, charm: str, method: str, user: str | None, group: str | None):
+    result = juju.run(
+        f'{charm}/0',
+        'chown',
+        params={'method': method, 'user': user or '', 'group': group or ''},
+    )
+    if user is not None:
+        assert result.results['user'] == user
+    if group is not None:
+        assert result.results['group'] == group


### PR DESCRIPTION
This PR aligns the behaviour of the file creation methods (`mkdir`, `write_bytes`, `write_text`) when the user argument is provided but the group argument is not.

In this case, Pebble sets the group based on the user (like `chown $user: $path`), while `shutil.chown` by default does not (like `chown $user $path`). Since changing the Pebble behaviour to match `shutil` here would require additional API calls (and possibly creating the directory twice?), and since the `user` and `group` arguments for the file creation methods are an API design that follows Pebble rather than `pathlib`, `LocalPath` is updated to follow Pebble's behaviour here.

This PR updates the unit tests to reflect this change, and adds a collection of integration tests for file ownership.

Documentation of the error case when `group` is provided without `user` for `ContainerPath` has also been added.

Resolves #39