### PR TITLE
fix: Fileinfo.{user,group} are typed optional but should always be there

### DIFF
--- a/pathops/src/charmlibs/pathops/_container_path.py
+++ b/pathops/src/charmlibs/pathops/_container_path.py
@@ -400,7 +400,9 @@ class ContainerPath:
             PebbleConnectionError: If the remote container cannot be reached.
         """
         info = _fileinfo.from_container_path(self)  # FileNotFoundError if path doesn't exist
-        return info.user or ''
+        user = info.user
+        assert user is not None
+        return user
 
     def group(self) -> str:
         """Return the group name of the file.
@@ -410,7 +412,9 @@ class ContainerPath:
             PebbleConnectionError: If the remote container cannot be reached.
         """
         info = _fileinfo.from_container_path(self)  # FileNotFoundError if path doesn't exist
-        return info.group or ''
+        group = info.group
+        assert group is not None
+        return group
 
     def exists(self) -> bool:
         """Whether this path exists.


### PR DESCRIPTION
The idea that these values might be `None` in the `FileInfo` originates from the `FileInfo.Sys` [call](https://github.com/canonical/pebble/blob/bd065c759e33f2d28583228f8f57ec535bf58d1c/internals/daemon/api_files.go#L256) in Pebble's code. However, it looks like this won't ever actually fail on the Linux implementation of this interface, so we don't need to pass this on to our users here.