### PR TITLE
fix: write methods no longer change existing mode unless it's passed explicitly

### DIFF
--- a/pathops/src/charmlibs/pathops/_container_path.py
+++ b/pathops/src/charmlibs/pathops/_container_path.py
@@ -520,6 +520,14 @@ class ContainerPath:
         if isinstance(data, (bytearray, memoryview)):
             # TODO: update ops to correctly test for bytearray and memoryview in push
             data = bytes(data)
+        if mode is None:
+            # if the file already exists, then don't change permissions unless explicitly requested
+            try:
+                info = _fileinfo.from_container_path(self)
+            except FileNotFoundError:
+                pass
+            else:
+                mode = info.permissions
         try:
             self._container.push(
                 path=self._path,

--- a/pathops/src/charmlibs/pathops/_container_path.py
+++ b/pathops/src/charmlibs/pathops/_container_path.py
@@ -508,7 +508,9 @@ class ContainerPath:
         Args:
             data: The bytes to write. If data is a :class:`bytearray` or :class:`memoryview`, it
                 will be converted to :class:`bytes` in memory first.
-            mode: The permissions to set on the file. Defaults to 0o644 (-rw-r--r--).
+            mode: The permissions to set on the file. Defaults to 0o644 (-rw-r--r--) for new files.
+                If the file already exists, it's permissions will be changed,
+                unless ``mode`` is ``None`` (default).
             user: The name of the user to set for the file.
                 If ``group`` isn't provided, the user's default group is used.
             group: The name of the group to set for the directory.
@@ -569,7 +571,9 @@ class ContainerPath:
         Args:
             data: The string to write. Will be encoded to :class:`bytes` in memory as UTF-8,
                 raising any errors. Newlines are not modified on writing.
-            mode: The permissions to set on the file. Defaults to 0o644 (-rw-r--r--).
+            mode: The permissions to set on the file. Defaults to 0o644 (-rw-r--r--) for new files.
+                If the file already exists, it's permissions will be changed,
+                unless ``mode`` is ``None`` (default).
             user: The name of the user to set for the file.
                 If ``group`` isn't provided, the user's default group is used.
             group: The name of the group to set for the directory.

--- a/pathops/src/charmlibs/pathops/_container_path.py
+++ b/pathops/src/charmlibs/pathops/_container_path.py
@@ -509,7 +509,7 @@ class ContainerPath:
             data: The bytes to write. If data is a :class:`bytearray` or :class:`memoryview`, it
                 will be converted to :class:`bytes` in memory first.
             mode: The permissions to set on the file. Defaults to 0o644 (-rw-r--r--) for new files.
-                If the file already exists, it's permissions will be changed,
+                If the file already exists, its permissions will be changed,
                 unless ``mode`` is ``None`` (default).
             user: The name of the user to set for the file.
                 If ``group`` isn't provided, the user's default group is used.
@@ -572,7 +572,7 @@ class ContainerPath:
             data: The string to write. Will be encoded to :class:`bytes` in memory as UTF-8,
                 raising any errors. Newlines are not modified on writing.
             mode: The permissions to set on the file. Defaults to 0o644 (-rw-r--r--) for new files.
-                If the file already exists, it's permissions will be changed,
+                If the file already exists, its permissions will be changed,
                 unless ``mode`` is ``None`` (default).
             user: The name of the user to set for the file.
                 If ``group`` isn't provided, the user's default group is used.

--- a/pathops/src/charmlibs/pathops/_container_path.py
+++ b/pathops/src/charmlibs/pathops/_container_path.py
@@ -492,7 +492,7 @@ class ContainerPath:
         self,
         data: bytes | bytearray | memoryview,
         *,
-        mode: int = _constants.DEFAULT_WRITE_MODE,
+        mode: int | None = None,
         user: str | None = None,
         group: str | None = None,
     ) -> int:
@@ -542,7 +542,7 @@ class ContainerPath:
         self,
         data: str,
         *,
-        mode: int = _constants.DEFAULT_WRITE_MODE,
+        mode: int | None = None,
         user: str | None = None,
         group: str | None = None,
     ) -> int:

--- a/pathops/src/charmlibs/pathops/_errors.py
+++ b/pathops/src/charmlibs/pathops/_errors.py
@@ -75,6 +75,10 @@ def raise_if_matches_lookup(error: pebble.Error, msg: str) -> None:
 
 def matches_not_a_directory(error: pebble.Error) -> bool:
     return (
+        isinstance(error, pebble.APIError)
+        and error.code == 400
+        and 'not a directory' in error.message
+    ) or (
         isinstance(error, pebble.PathError)
         and error.kind == 'generic-file-error'
         and 'not a directory' in error.message

--- a/pathops/src/charmlibs/pathops/_fileinfo.py
+++ b/pathops/src/charmlibs/pathops/_fileinfo.py
@@ -46,10 +46,11 @@ _FT_MAP: dict[int, pebble.FileType] = {
 def from_container_path(path: ContainerPath) -> pebble.FileInfo:
     try:
         (info,) = path._container.list_files(path._path, itself=True)
-    except pebble.APIError as e:
+    except (pebble.APIError, pebble.PathError) as e:
         msg = repr(path)
         _errors.raise_if_matches_file_not_found(e, msg=msg)
         _errors.raise_if_matches_not_a_directory(e, msg=msg)
+        _errors.raise_if_matches_permission(e, msg=msg)
         _errors.raise_if_matches_too_many_levels_of_symlinks(e, msg=msg)
         raise
     return info

--- a/pathops/src/charmlibs/pathops/_fileinfo.py
+++ b/pathops/src/charmlibs/pathops/_fileinfo.py
@@ -49,6 +49,7 @@ def from_container_path(path: ContainerPath) -> pebble.FileInfo:
     except pebble.APIError as e:
         msg = repr(path)
         _errors.raise_if_matches_file_not_found(e, msg=msg)
+        _errors.raise_if_matches_not_a_directory(e, msg=msg)
         _errors.raise_if_matches_too_many_levels_of_symlinks(e, msg=msg)
         raise
     return info

--- a/pathops/src/charmlibs/pathops/_local_path.py
+++ b/pathops/src/charmlibs/pathops/_local_path.py
@@ -60,8 +60,9 @@ class LocalPath(pathlib.PosixPath):
         Args:
             data: The bytes to write, typically a :class:`bytes` object, but may also be a
                 :class:`bytearray` or :class:`memoryview`.
-            mode: The permissions to set on the file using :meth:`pathlib.PosixPath.chmod`.
-                Defaults to 0o644 (-rw-r--r--).
+            mode: The permissions to set on the file. Defaults to 0o644 (-rw-r--r--) for new files.
+                If the file already exists, it's permissions will be changed, using
+                :meth:`pathlib.PosixPath.chmod`, unless ``mode`` is ``None`` (default).
             user: The name of the user to set for the file using :func:`shutil.chown`.
                 Validated to be an existing user before writing.
             group: The name of the group to set for the file using :func:`shutil.chown`.
@@ -119,8 +120,9 @@ class LocalPath(pathlib.PosixPath):
             newline: If ``None``, ``''``, or ``'\n'``, then '\n' will be written as is.
                 This is the default behaviour. If ``newline`` is ``'\r'`` or ``'\r\n'``,
                 then ``'\n'`` will be replaced with ``newline`` in memory before writing.
-            mode: The permissions to set on the file using :meth:`pathlib.PosixPath.chmod`.
-                Defaults to 0o644 (-rw-r--r--).
+            mode: The permissions to set on the file. Defaults to 0o644 (-rw-r--r--) for new files.
+                If the file already exists, it's permissions will be changed, using
+                :meth:`pathlib.PosixPath.chmod`, unless ``mode`` is ``None`` (default).
             user: The name of the user to set for the file using :func:`shutil.chown`.
                 Validated to be an existing user before writing.
             group: The name of the group to set for the file using :func:`shutil.chown`.

--- a/pathops/src/charmlibs/pathops/_local_path.py
+++ b/pathops/src/charmlibs/pathops/_local_path.py
@@ -61,7 +61,7 @@ class LocalPath(pathlib.PosixPath):
             data: The bytes to write, typically a :class:`bytes` object, but may also be a
                 :class:`bytearray` or :class:`memoryview`.
             mode: The permissions to set on the file. Defaults to 0o644 (-rw-r--r--) for new files.
-                If the file already exists, it's permissions will be changed, using
+                If the file already exists, its permissions will be changed, using
                 :meth:`pathlib.PosixPath.chmod`, unless ``mode`` is ``None`` (default).
             user: The name of the user to set for the file using :func:`shutil.chown`.
                 Validated to be an existing user before writing.
@@ -121,7 +121,7 @@ class LocalPath(pathlib.PosixPath):
                 This is the default behaviour. If ``newline`` is ``'\r'`` or ``'\r\n'``,
                 then ``'\n'`` will be replaced with ``newline`` in memory before writing.
             mode: The permissions to set on the file. Defaults to 0o644 (-rw-r--r--) for new files.
-                If the file already exists, it's permissions will be changed, using
+                If the file already exists, its permissions will be changed, using
                 :meth:`pathlib.PosixPath.chmod`, unless ``mode`` is ``None`` (default).
             user: The name of the user to set for the file using :func:`shutil.chown`.
                 Validated to be an existing user before writing.

--- a/pathops/src/charmlibs/pathops/_types.py
+++ b/pathops/src/charmlibs/pathops/_types.py
@@ -369,7 +369,7 @@ class PathProtocol(typing.Protocol):
             data: The bytes to write, typically a :class:`bytes` object, but may also be a
                 :class:`bytearray` or :class:`memoryview`.
             mode: The permissions to set on the file. Defaults to 0o644 (-rw-r--r--) for new files.
-                If the file already exists, it's permissions will be changed,
+                If the file already exists, its permissions will be changed,
                 unless ``mode`` is ``None`` (default).
             user: The name of the user to set for the directory.
                 If ``group`` isn't provided, the user's default group is used.
@@ -406,7 +406,7 @@ class PathProtocol(typing.Protocol):
         Args:
             data: The string to write. Newlines are not modified on writing.
             mode: The permissions to set on the file. Defaults to 0o644 (-rw-r--r--) for new files.
-                If the file already exists, it's permissions will be changed,
+                If the file already exists, its permissions will be changed,
                 unless ``mode`` is ``None`` (default).
             user: The name of the user to set for the directory.
                 If ``group`` isn't provided, the user's default group is used.

--- a/pathops/src/charmlibs/pathops/_types.py
+++ b/pathops/src/charmlibs/pathops/_types.py
@@ -356,7 +356,7 @@ class PathProtocol(typing.Protocol):
         self,
         data: bytes,
         *,
-        mode: int = _constants.DEFAULT_WRITE_MODE,
+        mode: int | None = None,
         user: str | None = None,
         group: str | None = None,
     ) -> int:
@@ -389,7 +389,7 @@ class PathProtocol(typing.Protocol):
         self,
         data: str,
         *,
-        mode: int = _constants.DEFAULT_WRITE_MODE,
+        mode: int | None = None,
         user: str | None = None,
         group: str | None = None,
     ) -> int:

--- a/pathops/src/charmlibs/pathops/_types.py
+++ b/pathops/src/charmlibs/pathops/_types.py
@@ -368,7 +368,9 @@ class PathProtocol(typing.Protocol):
         Args:
             data: The bytes to write, typically a :class:`bytes` object, but may also be a
                 :class:`bytearray` or :class:`memoryview`.
-            mode: The permissions to set on the file. Defaults to 0o644 (-rw-r--r--).
+            mode: The permissions to set on the file. Defaults to 0o644 (-rw-r--r--) for new files.
+                If the file already exists, it's permissions will be changed,
+                unless ``mode`` is ``None`` (default).
             user: The name of the user to set for the directory.
                 If ``group`` isn't provided, the user's default group is used.
             group: The name of the group to set for the directory. For :class:`ContainerPath`,
@@ -403,7 +405,9 @@ class PathProtocol(typing.Protocol):
 
         Args:
             data: The string to write. Newlines are not modified on writing.
-            mode: The permissions to set on the file. Defaults to 0o644 (-rw-r--r--).
+            mode: The permissions to set on the file. Defaults to 0o644 (-rw-r--r--) for new files.
+                If the file already exists, it's permissions will be changed,
+                unless ``mode`` is ``None`` (default).
             user: The name of the user to set for the directory.
                 If ``group`` isn't provided, the user's default group is used.
             group: The name of the group to set for the directory. For :class:`ContainerPath`,

--- a/pathops/tests/integration/pebble/test_local_path.py
+++ b/pathops/tests/integration/pebble/test_local_path.py
@@ -157,10 +157,7 @@ def test_write_methods_chmod(
         path.chmod(exists_with_mode)
     else:
         assert not path.exists()
-    if mode is not None:
-        container_path_method(data, mode=mode)
-    else:
-        container_path_method(data)
+    container_path_method(data, mode=mode)
     assert path.exists()
     container_info = _get_fileinfo(container_path)
     # cleanup
@@ -173,10 +170,7 @@ def test_write_methods_chmod(
         path.chmod(exists_with_mode)
     else:
         assert not path.exists()
-    if mode is not None:
-        local_path_method(data, mode=mode)
-    else:
-        local_path_method(data)
+    local_path_method(data, mode=mode)
     assert path.exists()
     local_info = _get_fileinfo(local_path)
     # cleanup
@@ -185,8 +179,12 @@ def test_write_methods_chmod(
     container_dict = utils.info_to_dict(container_info, exclude=exclude)
     local_dict = utils.info_to_dict(local_info, exclude=exclude)
     assert local_dict == container_dict
-    expected_permissions = mode if mode is not None else DEFAULT_WRITE_MODE
-    assert local_dict['permissions'] == expected_permissions
+    if mode is not None:
+        assert local_dict['permissions'] == mode
+    elif exists_with_mode is not None:
+        assert local_dict['permissions'] == exists_with_mode
+    else:
+        assert local_dict['permissions'] == DEFAULT_WRITE_MODE
 
 
 @pytest.mark.parametrize('mode_str', [*ALL_MODES, None])

--- a/pathops/tests/integration/pebble/test_local_path.py
+++ b/pathops/tests/integration/pebble/test_local_path.py
@@ -134,19 +134,24 @@ class TestChown:
 
 @pytest.mark.parametrize(('method', 'data'), [('write_bytes', b'bytes'), ('write_text', 'text')])
 @pytest.mark.parametrize('mode_str', [None, *ALL_MODES])
+@pytest.mark.parametrize('exists', [True, False])
 def test_write_methods_chmod(
     container: ops.Container,
     tmp_path: pathlib.Path,
     method: str,
     data: str | bytes,
     mode_str: str | None,
+    exists: bool,
 ):
     mode = int(mode_str, base=8) if mode_str is not None else None
     path = tmp_path / 'path'
     # container
     container_path = ContainerPath(path, container=container)
     container_path_method = getattr(container_path, method)
-    assert not path.exists()
+    if exists:
+        path.write_bytes(b'')
+    else:
+        assert not path.exists()
     if mode is not None:
         container_path_method(data, mode=mode)
     else:
@@ -158,7 +163,10 @@ def test_write_methods_chmod(
     # local
     local_path = LocalPath(path)
     local_path_method = getattr(local_path, method)
-    assert not path.exists()
+    if exists:
+        path.write_bytes(b'')
+    else:
+        assert not path.exists()
     if mode is not None:
         local_path_method(data, mode=mode)
     else:

--- a/pathops/tests/integration/pebble/test_local_path.py
+++ b/pathops/tests/integration/pebble/test_local_path.py
@@ -184,7 +184,7 @@ def test_write_methods_chmod(
     elif exists_with_mode is not None:
         assert local_dict['permissions'] == exists_with_mode
     else:
-        assert local_dict['permissions'] == DEFAULT_WRITE_MODE
+        assert local_dict['permissions'] == _constants.DEFAULT_WRITE_MODE
 
 
 @pytest.mark.parametrize('mode_str', [*ALL_MODES, None])

--- a/pathops/tests/integration/pebble/test_local_path.py
+++ b/pathops/tests/integration/pebble/test_local_path.py
@@ -26,7 +26,6 @@ import pytest
 
 import utils
 from charmlibs.pathops import ContainerPath, LocalPath, _constants
-from charmlibs.pathops._constants import DEFAULT_WRITE_MODE
 from charmlibs.pathops._functions import _get_fileinfo
 
 if typing.TYPE_CHECKING:
@@ -137,7 +136,8 @@ class TestChown:
 @pytest.mark.parametrize(('method', 'data'), [('write_bytes', b'bytes'), ('write_text', 'text')])
 @pytest.mark.parametrize('mode_str', [None, *ALL_MODES])
 @pytest.mark.parametrize(
-    'exists_with_mode', [None, DEFAULT_WRITE_MODE, DEFAULT_WRITE_MODE | stat.S_IXOTH]
+    'exists_with_mode',
+    (None, _constants.DEFAULT_WRITE_MODE, _constants.DEFAULT_WRITE_MODE | stat.S_IXOTH),
 )
 def test_write_methods_chmod(
     container: ops.Container,

--- a/pathops/tests/unit/test_container_path.py
+++ b/pathops/tests/unit/test_container_path.py
@@ -25,7 +25,7 @@ import pytest
 from ops import pebble
 
 import utils
-from charmlibs.pathops import ContainerPath, LocalPath, RelativePathError, _fileinfo
+from charmlibs.pathops import ContainerPath, LocalPath, RelativePathError, _constants, _fileinfo
 
 if typing.TYPE_CHECKING:
     from typing import Any, Callable
@@ -324,13 +324,15 @@ def test_exists_reraises_unhandled_os_error(
 
 
 @pytest.mark.parametrize(
-    ('path_method', 'container_method', 'args'),
+    ('path_method', 'container_method', 'args', 'kwargs'),
     (
-        ('read_bytes', 'pull', ()),
-        ('read_text', 'pull', ()),
-        ('write_bytes', 'list_files', (b'',)),
-        ('write_text', 'list_files', ('',)),
-        ('mkdir', 'make_dir', ()),
+        ('read_bytes', 'pull', (), {}),
+        ('read_text', 'pull', (), {}),
+        ('write_bytes', 'list_files', (b'',), {}),
+        ('write_bytes', 'push', (b'',), {'mode': _constants.DEFAULT_WRITE_MODE}),
+        ('write_text', 'list_files', ('',), {}),
+        ('write_text', 'push', ('',), {'mode': _constants.DEFAULT_WRITE_MODE}),
+        ('mkdir', 'make_dir', (), {}),
     ),
 )
 @pytest.mark.parametrize(
@@ -349,11 +351,12 @@ def test_methods_handle_or_reraise_pebble_errors(
     path_method: str,
     container_method: str,
     args: tuple[object],
+    kwargs: dict[str, object],
 ):
     monkeypatch.setattr(container, container_method, mock)
     containerpath_method = getattr(ContainerPath, path_method)
     with pytest.raises(error):
-        containerpath_method(ContainerPath('/', container=container), *args)
+        containerpath_method(ContainerPath('/', container=container), *args, **kwargs)
 
 
 @pytest.mark.parametrize(

--- a/pathops/tests/unit/test_container_path.py
+++ b/pathops/tests/unit/test_container_path.py
@@ -328,8 +328,8 @@ def test_exists_reraises_unhandled_os_error(
     (
         ('read_bytes', 'pull', ()),
         ('read_text', 'pull', ()),
-        ('write_bytes', 'push', (b'',)),
-        ('write_text', 'push', ('',)),
+        ('write_bytes', 'list_files', (b'',)),
+        ('write_text', 'list_files', ('',)),
         ('mkdir', 'make_dir', ()),
     ),
 )


### PR DESCRIPTION
The current behaviour of both `ContainerPath` and `LocalPath` for `write_{bytes,text}` is to always set the mode -- even setting the default mode if none is provided. I think overriding any existing file permissions with the default when none is provided is a mistake, as (e.g.) `pathlib.Path.write_bytes(data)` doesn't change any existing file permissions. This PR modifies these methods so that the permissions are only changed if the `mode` argument is not `None`.

Tests have been expanded to cover the case of writing when the target file already exists, and updated to reflect this new behaviour.

Resolves #46