### PR TITLE
fix: consistent behaviour for mkdir chown args when exists

### DIFF
--- a/pathops/src/charmlibs/pathops/_container_path.py
+++ b/pathops/src/charmlibs/pathops/_container_path.py
@@ -513,8 +513,12 @@ class ContainerPath:
                 unless ``mode`` is ``None`` (default).
             user: The name of the user to set for the file.
                 If ``group`` isn't provided, the user's default group is used.
+                If the file already exists, its user and group will be changed,
+                unless ``user`` is ``None`` (default).
             group: The name of the group to set for the directory.
                 It is an error to provide ``group`` if ``user`` isn't provided.
+                If the file already exists, its group will be changed,
+                unless ``user`` and ``group`` are ``None`` (default).
 
         Returns: The number of bytes written.
 
@@ -579,8 +583,12 @@ class ContainerPath:
                 unless ``mode`` is ``None`` (default).
             user: The name of the user to set for the file.
                 If ``group`` isn't provided, the user's default group is used.
+                If the file already exists, its user and group will be changed,
+                unless ``user`` is ``None`` (default).
             group: The name of the group to set for the directory.
                 It is an error to provide ``group`` if ``user`` isn't provided.
+                If the file already exists, its group will be changed,
+                unless ``user`` and ``group`` are ``None`` (default).
 
         Returns: The number of bytes written.
 

--- a/pathops/src/charmlibs/pathops/_container_path.py
+++ b/pathops/src/charmlibs/pathops/_container_path.py
@@ -526,14 +526,21 @@ class ContainerPath:
         if isinstance(data, (bytearray, memoryview)):
             # TODO: update ops to correctly test for bytearray and memoryview in push
             data = bytes(data)
+        if user is None:
+            try:
+                info = _fileinfo.from_container_path(self)
+            except FileNotFoundError:
+                pass
+            else:
+                user = info.user
         try:
             self._container.push(
                 path=self._path,
                 source=data,
                 make_dirs=False,
                 permissions=mode,
-                user=user if isinstance(user, str) else None,
-                group=group if isinstance(group, str) else None,
+                user=user,
+                group=group,
             )
         except pebble.PathError as e:
             _errors.raise_if_matches_lookup(e, msg=e.message)

--- a/pathops/src/charmlibs/pathops/_container_path.py
+++ b/pathops/src/charmlibs/pathops/_container_path.py
@@ -620,6 +620,7 @@ class ContainerPath:
         Args:
             mode: The permissions to set on the created directory. Any parents created will have
                 their permissions set to the default value of 0o755 (drwxr-xr-x).
+                The permissions are not changed if the directory already exists.
             parents: Whether to create any missing parent directories as well. If ``False``
                 (default) and a parent directory does not exist, a :class:`FileNotFound` error will
                 be raised.
@@ -628,8 +629,10 @@ class ContainerPath:
                 a :class:`FileExistsError` will be raised.
             user: The name of the user to set for the directory.
                 If ``group`` isn't provided, the user's default group is used.
+                The user and group are not changed if the directory already exists.
             group: The name of the group to set for the directory.
                 It is an error to provide ``group`` if ``user`` isn't provided.
+                The user and group are not changed if the directory already exists.
 
         Raises:
             FileExistsError: if the directory already exists and ``exist_ok`` is ``False``.

--- a/pathops/src/charmlibs/pathops/_local_path.py
+++ b/pathops/src/charmlibs/pathops/_local_path.py
@@ -65,8 +65,12 @@ class LocalPath(pathlib.PosixPath):
                 :meth:`pathlib.PosixPath.chmod`, unless ``mode`` is ``None`` (default).
             user: The name of the user to set for the file using :func:`shutil.chown`.
                 Validated to be an existing user before writing.
+                If the file already exists, its user and group will be changed,
+                unless ``user`` is ``None`` (default).
             group: The name of the group to set for the file using :func:`shutil.chown`.
                 Validated to be an existing group before writing.
+                If the file already exists, its group will be changed,
+                unless ``user`` and ``group`` are ``None`` (default).
 
         Returns:
             The number of bytes written.
@@ -125,8 +129,12 @@ class LocalPath(pathlib.PosixPath):
                 :meth:`pathlib.PosixPath.chmod`, unless ``mode`` is ``None`` (default).
             user: The name of the user to set for the file using :func:`shutil.chown`.
                 Validated to be an existing user before writing.
+                If the file already exists, its user and group will be changed,
+                unless ``user`` is ``None`` (default).
             group: The name of the group to set for the file using :func:`shutil.chown`.
                 Validated to be an existing group before writing.
+                If the file already exists, its group will be changed,
+                unless ``user`` and ``group`` are ``None`` (default).
 
         Returns:
             The number of bytes written.

--- a/pathops/src/charmlibs/pathops/_local_path.py
+++ b/pathops/src/charmlibs/pathops/_local_path.py
@@ -179,6 +179,7 @@ class LocalPath(pathlib.PosixPath):
         Args:
             mode: The permissions to set on the created directory. Any parents created will have
                 their permissions set to the default value of 0o755 (drwxr-xr-x).
+                The permissions are not changed if the directory already exists.
             parents: Whether to create any missing parent directories as well. If ``False``
                 (default) and a parent directory does not exist, a :class:`FileNotFound` error will
                 be raised.
@@ -187,8 +188,10 @@ class LocalPath(pathlib.PosixPath):
                 a :class:`FileExistsError` will be raised.
             user: The name of the user to set for the directory using :func:`shutil.chown`.
                 Validated to be an existing user before writing.
+                The user and group are not changed if the directory already exists.
             group: The name of the group to set for the directory using :func:`shutil.chown`.
                 Validated to be an existing group before writing.
+                The user and group are not changed if the directory already exists.
 
         Raises:
             FileExistsError: if the directory already exists and ``exist_ok`` is ``False``.

--- a/pathops/src/charmlibs/pathops/_local_path.py
+++ b/pathops/src/charmlibs/pathops/_local_path.py
@@ -177,8 +177,10 @@ class LocalPath(pathlib.PosixPath):
             PermissionError: if the local user does not have permissions for the operation.
         """
         _validate_user_and_group(user=user, group=group)
+        already_exists = self.exists()
         super().mkdir(mode=mode, parents=parents, exist_ok=exist_ok)
-        _chown_if_needed(self, user=user, group=group)
+        if not already_exists:
+            _chown_if_needed(self, user=user, group=group)
 
 
 def _validate_user_and_group(user: str | None, group: str | None):

--- a/pathops/src/charmlibs/pathops/_types.py
+++ b/pathops/src/charmlibs/pathops/_types.py
@@ -373,8 +373,12 @@ class PathProtocol(typing.Protocol):
                 unless ``mode`` is ``None`` (default).
             user: The name of the user to set for the directory.
                 If ``group`` isn't provided, the user's default group is used.
+                If the file already exists, its user and group will be changed,
+                unless ``user`` is ``None`` (default).
             group: The name of the group to set for the directory. For :class:`ContainerPath`,
                 it is an error to provide ``group`` if ``user`` isn't provided.
+                If the file already exists, its group will be changed,
+                unless ``user`` and ``group`` are ``None`` (default).
 
         Returns:
             The number of bytes written.
@@ -410,8 +414,12 @@ class PathProtocol(typing.Protocol):
                 unless ``mode`` is ``None`` (default).
             user: The name of the user to set for the directory.
                 If ``group`` isn't provided, the user's default group is used.
+                If the file already exists, its user and group will be changed,
+                unless ``user`` is ``None`` (default).
             group: The name of the group to set for the directory. For :class:`ContainerPath`,
                 it is an error to provide ``group`` if ``user`` isn't provided.
+                If the file already exists, its group will be changed,
+                unless ``user`` and ``group`` are ``None`` (default).
 
         Returns:
             The number of bytes written.

--- a/pathops/src/charmlibs/pathops/_types.py
+++ b/pathops/src/charmlibs/pathops/_types.py
@@ -452,6 +452,7 @@ class PathProtocol(typing.Protocol):
         Args:
             mode: The permissions to set on the created directory. Any parents created will have
                 their permissions set to the default value of 0o755 (drwxr-xr-x).
+                The permissions are not changed if the directory already exists.
             parents: Whether to create any missing parent directories as well. If ``False``
                 (default) and a parent directory does not exist, a :class:`FileNotFound` error will
                 be raised.
@@ -460,8 +461,10 @@ class PathProtocol(typing.Protocol):
                 a :class:`FileExistsError` will be raised.
             user: The name of the user to set for the directory.
                 If ``group`` isn't provided, the user's default group is used.
+                The user and group are not changed if the directory already exists.
             group: The name of the group to set for the directory. For :class:`ContainerPath`,
                 it is an error to provide ``group`` if ``user`` isn't provided.
+                The user and group are not changed if the directory already exists.
 
         Raises:
             FileExistsError: if the directory already exists and ``exist_ok`` is ``False``.

--- a/pathops/tests/integration/juju/charms/kubernetes/charmcraft.yaml
+++ b/pathops/tests/integration/juju/charms/kubernetes/charmcraft.yaml
@@ -43,3 +43,6 @@ actions:
         type: string
       group:
         type: string
+      already-exists:
+        type: boolean
+        default: false

--- a/pathops/tests/integration/juju/charms/kubernetes/src/charm.py
+++ b/pathops/tests/integration/juju/charms/kubernetes/src/charm.py
@@ -43,7 +43,7 @@ class Charm(common.Charm):
         super().__init__(framework)
         framework.observe(self.on[CONTAINER].pebble_ready, self._on_pebble_ready)
         self.container = self.unit.get_container(CONTAINER)
-        self.root = pathops.ContainerPath('/', 'tmp', container=self.container)
+        self.root = pathops.ContainerPath('/', container=self.container)
 
     def _on_pebble_ready(self, event: ops.PebbleReadyEvent):
         """Handle pebble-ready event."""

--- a/pathops/tests/integration/juju/charms/kubernetes/src/common.py
+++ b/pathops/tests/integration/juju/charms/kubernetes/src/common.py
@@ -101,7 +101,7 @@ class Charm(ops.CharmBase):
                 assert path.owner() == temp_user
                 assert path.owner() == temp_user
             if method == 'mkdir':
-                path.mkdir(user=user, group=group)
+                path.mkdir(user=user, group=group, exist_ok=True)
             elif method == 'write_bytes':
                 path.write_bytes(b'', user=user, group=group)
             elif method == 'write_text':
@@ -111,7 +111,9 @@ class Charm(ops.CharmBase):
             event.set_results({'user': path.owner(), 'group': path.group()})
         except Exception as e:
             tb = traceback.format_exc()
-            event.fail(f'Exception: {e!r}\n{tb}')
+            msg = f'Exception: {e!r}\n{tb}'
+            event.fail(msg)
+            logger.error('chown action failed: %s', msg)
         finally:
             self.remove_path(path)
             self.remove_user(temp_user)

--- a/pathops/tests/integration/juju/charms/kubernetes/src/common.py
+++ b/pathops/tests/integration/juju/charms/kubernetes/src/common.py
@@ -113,7 +113,6 @@ class Charm(ops.CharmBase):
             tb = traceback.format_exc()
             msg = f'Exception: {e!r}\n{tb}'
             event.fail(msg)
-            logger.error('chown action failed: %s', msg)
         finally:
             self.remove_path(path)
             self.remove_user(temp_user)

--- a/pathops/tests/integration/juju/charms/kubernetes/src/common.py
+++ b/pathops/tests/integration/juju/charms/kubernetes/src/common.py
@@ -20,6 +20,7 @@ The contents of kubernetes/src/common.py and machine/src/common.py should be ide
 from __future__ import annotations
 
 import logging
+import traceback
 import typing
 
 import ops
@@ -53,9 +54,11 @@ class Charm(ops.CharmBase):
         framework.observe(self.on['chown'].action, self._on_chown)
 
     def remove_path(self, path: pathops.PathProtocol, recursive: bool = False) -> None:
+        """Remove a path following Pebble remove_path semantics if it exists."""
         raise NotImplementedError()
 
     def exec(self, cmd: Sequence[str]) -> int:
+        """Run a command and return the exit code."""
         raise NotImplementedError()
 
     def _on_ensure_contents(self, event: ops.ActionEvent) -> None:
@@ -83,12 +86,20 @@ class Charm(ops.CharmBase):
         if path.exists():
             event.fail('File already exists.')
             return
-        method: str = event.params['method']
-        user: str | None = event.params['user'] or None
-        group: str | None = event.params['group'] or None
         temp_user = 'temp-user'
-        self.add_user(temp_user)
         try:
+            method: str = event.params['method']
+            user: str | None = event.params['user'] or None
+            group: str | None = event.params['group'] or None
+            already_exists: bool = event.params['already-exists']
+            self.add_user(temp_user)
+            if already_exists:
+                if method == 'mkdir':
+                    path.mkdir(user=temp_user)
+                else:
+                    path.write_bytes(b'', user=temp_user)
+                assert path.owner() == temp_user
+                assert path.owner() == temp_user
             if method == 'mkdir':
                 path.mkdir(user=user, group=group)
             elif method == 'write_bytes':
@@ -99,7 +110,8 @@ class Charm(ops.CharmBase):
                 raise ValueError(f'Unknown method: {method!r}')
             event.set_results({'user': path.owner(), 'group': path.group()})
         except Exception as e:
-            event.fail(f'Exception: {e!r}')
+            tb = traceback.format_exc()
+            event.fail(f'Exception: {e!r}\n{tb}')
         finally:
             self.remove_path(path)
             self.remove_user(temp_user)

--- a/pathops/tests/integration/juju/charms/kubernetes/src/common.py
+++ b/pathops/tests/integration/juju/charms/kubernetes/src/common.py
@@ -97,7 +97,7 @@ class Charm(ops.CharmBase):
                 if method == 'mkdir':
                     path.mkdir(user=temp_user)
                 else:
-                    path.write_bytes(b'', user=temp_user)
+                    path.write_bytes(b'', user=temp_user, mode=0o777)
                 assert path.owner() == temp_user
                 assert path.owner() == temp_user
             if method == 'mkdir':

--- a/pathops/tests/integration/juju/charms/machine/charmcraft.yaml
+++ b/pathops/tests/integration/juju/charms/machine/charmcraft.yaml
@@ -33,3 +33,6 @@ actions:
         type: string
       group:
         type: string
+      already-exists:
+        type: boolean
+        default: false

--- a/pathops/tests/integration/juju/charms/machine/src/charm.py
+++ b/pathops/tests/integration/juju/charms/machine/src/charm.py
@@ -42,7 +42,7 @@ class Charm(common.Charm):
     def __init__(self, framework: ops.Framework):
         super().__init__(framework)
         framework.observe(self.on.start, self._on_start)
-        self.root = pathops.LocalPath('/', 'tmp')
+        self.root = pathops.LocalPath('/')
 
     def _on_start(self, event: ops.StartEvent):
         """Handle start event."""

--- a/pathops/tests/integration/juju/charms/machine/src/common.py
+++ b/pathops/tests/integration/juju/charms/machine/src/common.py
@@ -101,7 +101,7 @@ class Charm(ops.CharmBase):
                 assert path.owner() == temp_user
                 assert path.owner() == temp_user
             if method == 'mkdir':
-                path.mkdir(user=user, group=group)
+                path.mkdir(user=user, group=group, exist_ok=True)
             elif method == 'write_bytes':
                 path.write_bytes(b'', user=user, group=group)
             elif method == 'write_text':
@@ -111,7 +111,9 @@ class Charm(ops.CharmBase):
             event.set_results({'user': path.owner(), 'group': path.group()})
         except Exception as e:
             tb = traceback.format_exc()
-            event.fail(f'Exception: {e!r}\n{tb}')
+            msg = f'Exception: {e!r}\n{tb}'
+            event.fail(msg)
+            logger.error('chown action failed: %s', msg)
         finally:
             self.remove_path(path)
             self.remove_user(temp_user)

--- a/pathops/tests/integration/juju/charms/machine/src/common.py
+++ b/pathops/tests/integration/juju/charms/machine/src/common.py
@@ -113,7 +113,6 @@ class Charm(ops.CharmBase):
             tb = traceback.format_exc()
             msg = f'Exception: {e!r}\n{tb}'
             event.fail(msg)
-            logger.error('chown action failed: %s', msg)
         finally:
             self.remove_path(path)
             self.remove_user(temp_user)

--- a/pathops/tests/integration/juju/charms/machine/src/common.py
+++ b/pathops/tests/integration/juju/charms/machine/src/common.py
@@ -20,6 +20,7 @@ The contents of kubernetes/src/common.py and machine/src/common.py should be ide
 from __future__ import annotations
 
 import logging
+import traceback
 import typing
 
 import ops
@@ -53,9 +54,11 @@ class Charm(ops.CharmBase):
         framework.observe(self.on['chown'].action, self._on_chown)
 
     def remove_path(self, path: pathops.PathProtocol, recursive: bool = False) -> None:
+        """Remove a path following Pebble remove_path semantics if it exists."""
         raise NotImplementedError()
 
     def exec(self, cmd: Sequence[str]) -> int:
+        """Run a command and return the exit code."""
         raise NotImplementedError()
 
     def _on_ensure_contents(self, event: ops.ActionEvent) -> None:
@@ -83,12 +86,20 @@ class Charm(ops.CharmBase):
         if path.exists():
             event.fail('File already exists.')
             return
-        method: str = event.params['method']
-        user: str | None = event.params['user'] or None
-        group: str | None = event.params['group'] or None
         temp_user = 'temp-user'
-        self.add_user(temp_user)
         try:
+            method: str = event.params['method']
+            user: str | None = event.params['user'] or None
+            group: str | None = event.params['group'] or None
+            already_exists: bool = event.params['already-exists']
+            self.add_user(temp_user)
+            if already_exists:
+                if method == 'mkdir':
+                    path.mkdir(user=temp_user)
+                else:
+                    path.write_bytes(b'', user=temp_user)
+                assert path.owner() == temp_user
+                assert path.owner() == temp_user
             if method == 'mkdir':
                 path.mkdir(user=user, group=group)
             elif method == 'write_bytes':
@@ -99,7 +110,8 @@ class Charm(ops.CharmBase):
                 raise ValueError(f'Unknown method: {method!r}')
             event.set_results({'user': path.owner(), 'group': path.group()})
         except Exception as e:
-            event.fail(f'Exception: {e!r}')
+            tb = traceback.format_exc()
+            event.fail(f'Exception: {e!r}\n{tb}')
         finally:
             self.remove_path(path)
             self.remove_user(temp_user)

--- a/pathops/tests/integration/juju/charms/machine/src/common.py
+++ b/pathops/tests/integration/juju/charms/machine/src/common.py
@@ -97,7 +97,7 @@ class Charm(ops.CharmBase):
                 if method == 'mkdir':
                     path.mkdir(user=temp_user)
                 else:
-                    path.write_bytes(b'', user=temp_user)
+                    path.write_bytes(b'', user=temp_user, mode=0o777)
                 assert path.owner() == temp_user
                 assert path.owner() == temp_user
             if method == 'mkdir':

--- a/pathops/tests/integration/juju/test_pathops.py
+++ b/pathops/tests/integration/juju/test_pathops.py
@@ -77,8 +77,15 @@ def test_chown(
     except jubilant.TaskError as e:
         print(e)
         print(e.task.message)
-        if charm == 'kubernetes' and user is None and group is not None:
+        if (
+            charm == 'kubernetes'
+            and user is None
+            and group is not None
+            and (method == 'mkdir' or not already_exists)
+        ):
             # we expect the group-only case to fail (unless Pebble is updated to handle it)
+            # although if the file already exists and the method is write_{bytes,text} then
+            # it succeeds because we look up the user to avoid clobbering the file ownership
             prefix = 'Exception: '
             assert e.task.message.startswith(prefix)
             msg = e.task.message[len(prefix) :]

--- a/pathops/tests/integration/juju/test_pathops.py
+++ b/pathops/tests/integration/juju/test_pathops.py
@@ -75,6 +75,8 @@ def test_chown(
     try:
         result = juju.run(f'{charm}/0', 'chown', params=params)
     except jubilant.TaskError as e:
+        print(e)
+        print(e.task.message)
         if charm == 'kubernetes' and user is None and group is not None:
             # we expect the group-only case to fail (unless Pebble is updated to handle it)
             prefix = 'Exception: '

--- a/pathops/tests/integration/juju/test_pathops.py
+++ b/pathops/tests/integration/juju/test_pathops.py
@@ -88,6 +88,6 @@ def test_chown(
         expected_group = 'temp-user'
         assert (result.results['user'], result.results['group']) == (expected_user, expected_group)
     else:
-        expected_user = user if user is not None else 'root'
+        expected_user = user if user is not None else 'temp-user'
         expected_group = group if group is not None else expected_user
         assert (result.results['user'], result.results['group']) == (expected_user, expected_group)

--- a/pathops/tests/integration/juju/test_pathops.py
+++ b/pathops/tests/integration/juju/test_pathops.py
@@ -83,11 +83,18 @@ def test_chown(
             assert msg.startswith('LookupError')
             return
         raise
-    if already_exists and method == 'mkdir':
-        expected_user = 'temp-user'
-        expected_group = 'temp-user'
-        assert (result.results['user'], result.results['group']) == (expected_user, expected_group)
-    else:
-        expected_user = user if user is not None else 'temp-user'
+    user_result = result.results['user']
+    group_result = result.results['group']
+    if already_exists:
+        if method == 'mkdir':
+            expected_user = 'temp-user'
+            expected_group = 'temp-user'
+            assert (user_result, group_result) == (expected_user, expected_group)
+        else:  # write_{bytes,text}
+            expected_user = user if user is not None else 'temp-user'
+            expected_group = group if group is not None else expected_user
+            assert (user_result, group_result) == (expected_user, expected_group)
+    else:  # not already_exists
+        expected_user = user if user is not None else 'root'
         expected_group = group if group is not None else expected_user
         assert (result.results['user'], result.results['group']) == (expected_user, expected_group)

--- a/pathops/tests/integration/juju/test_pathops.py
+++ b/pathops/tests/integration/juju/test_pathops.py
@@ -70,7 +70,7 @@ def test_chown(
         'method': method,
         'user': user or '',
         'group': group or '',
-        'already-exists': already_exists
+        'already-exists': already_exists,
     }
     try:
         result = juju.run(f'{charm}/0', 'chown', params=params)

--- a/pathops/tests/unit/test_container_path.py
+++ b/pathops/tests/unit/test_container_path.py
@@ -329,9 +329,9 @@ def test_exists_reraises_unhandled_os_error(
         ('read_bytes', 'pull', (), {}),
         ('read_text', 'pull', (), {}),
         ('write_bytes', 'list_files', (b'',), {}),
-        ('write_bytes', 'push', (b'',), {'mode': _constants.DEFAULT_WRITE_MODE}),
+        ('write_bytes', 'push', (b'',), {'mode': _constants.DEFAULT_WRITE_MODE, 'user': ''}),
         ('write_text', 'list_files', ('',), {}),
-        ('write_text', 'push', ('',), {'mode': _constants.DEFAULT_WRITE_MODE}),
+        ('write_text', 'push', ('',), {'mode': _constants.DEFAULT_WRITE_MODE, 'user': ''}),
         ('mkdir', 'make_dir', (), {}),
     ),
 )


### PR DESCRIPTION
This PR makes the behaviour of the `user` and `group` args to the file creation methods consistent.

- If the file already exists, `ContainerPath.write_{bytes,text}` will no longer modify the `user` or `group` if they're not supplied explicitly, just like how we recently updated these methods to not change the `mode` if it's not supplied explicitly in #47 
- If the directory already exists, `LocalPath.mkdir` will no longer modify the `user` or `group`, even if they're passed explicitly, matching the current `ContainerPath.mkdir` behaviour, and matching the behaviour of `mode` for `mkdir`.

This PR also adds Juju integration tests to cover the `user` and `group` behaviour when the target file or directory already exists, and updates the unit tests to work with the new behaviour.

Resolves #49