### PR TITLE
docs: expand the charmlibs package readme

### DIFF
--- a/_charmlibs/README.md
+++ b/_charmlibs/README.md
@@ -2,6 +2,10 @@
 
 This package should not be installed - it exists solely to reserve the `charmlibs` namespace.
 
-This namespace is for packages designed to be used by [Juju charms](https://juju.is/charms-architecture).
+This namespace is for packages designed to be used by [Juju charms](https://juju.is/charms-architecture). Visit the [charmlibs documentation site](https://canonical-charmlibs.readthedocs-hosted.com/) for more information about charm libraries.
 
-See the Juju documentation to [get started with charm development](https://documentation.ubuntu.com/juju/3.6/howto/manage-charms/#build-a-charm), and visit the [charmlibs documentation site](https://canonical-charmlibs.readthedocs-hosted.com/) for more information about charm libraries. You can also read more about [distributing your own charm library as a Python package](https://canonical-charmlibs.readthedocs-hosted.com/how-to/python-package/#how-to-python-package).
+See more:
+
+- Get started with charm development, using [Charmcraft tutorials](https://canonical-charmcraft.readthedocs-hosted.com/en/stable/tutorial/) and [Ops tutorials](https://ops.readthedocs.io/en/latest/tutorial/index.html)
+- Learn how to [use and write charm libraries](https://ops.readthedocs.io/en/latest/howto/manage-libraries.html)
+- Learn how to [distribute your own charm library as a Python package](https://canonical-charmlibs.readthedocs-hosted.com/how-to/python-package/)

--- a/_charmlibs/README.md
+++ b/_charmlibs/README.md
@@ -2,4 +2,6 @@
 
 This package should not be installed - it exists solely to reserve the `charmlibs` namespace.
 
-See the [charmlibs documentation site](https://canonical-charmlibs.readthedocs-hosted.com/) for more information.
+This namespace is for packages designed to be used by [Juju](https://juju.is/) [charms](https://juju.is/charms-architecture).
+
+See the Juju documentation to [get started with charm development](https://documentation.ubuntu.com/juju/3.6/howto/manage-charms/#build-a-charm), and visit the [charmlibs documentation site](https://canonical-charmlibs.readthedocs-hosted.com/) for more information about charm libraries. You can also read more about [distributing your own charm library as a Python package](https://canonical-charmlibs.readthedocs-hosted.com/how-to/python-package/#how-to-python-package).

--- a/_charmlibs/README.md
+++ b/_charmlibs/README.md
@@ -2,6 +2,6 @@
 
 This package should not be installed - it exists solely to reserve the `charmlibs` namespace.
 
-This namespace is for packages designed to be used by [Juju](https://juju.is/) [charms](https://juju.is/charms-architecture).
+This namespace is for packages designed to be used by [Juju charms](https://juju.is/charms-architecture).
 
 See the Juju documentation to [get started with charm development](https://documentation.ubuntu.com/juju/3.6/howto/manage-charms/#build-a-charm), and visit the [charmlibs documentation site](https://canonical-charmlibs.readthedocs-hosted.com/) for more information about charm libraries. You can also read more about [distributing your own charm library as a Python package](https://canonical-charmlibs.readthedocs-hosted.com/how-to/python-package/#how-to-python-package).

--- a/_charmlibs/pyproject.toml
+++ b/_charmlibs/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Intended Audience :: Developers",
     "Operating System :: POSIX :: Linux",
-    "Development Status :: 2 - Pre-Alpha",
+    "Development Status :: 5 - Production/Stable",
 ]
 dynamic = ["version"]
 

--- a/_charmlibs/src/charmlibs/__init__.py
+++ b/_charmlibs/src/charmlibs/__init__.py
@@ -19,6 +19,6 @@ For more information, see the PyPI page at https://pypi.org/project/charmlibs
 
 import warnings
 
-__version__ = '0.0.0a2'
+__version__ = '1.0.0a0'
 
 warnings.warn('This package should not be installed.', stacklevel=1)


### PR DESCRIPTION
This PR expands the charmlibs package readme with additional information. This readme appears both [in the repo](https://github.com/canonical/charmtech-charmlibs/tree/main/_charmlibs) and [on PyPI](https://pypi.org/project/charmlibs/).

This PR also bumps the charmlibs package version and development status in preparation for release.