### PR TITLE
chore: allow pathops to run with ops 3

### DIFF
--- a/pathops/pyproject.toml
+++ b/pathops/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "ops~=2.19",
+    "ops>=2.19,<4",
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR broadens the dependency range of `ops` for `pathops`, to allow `pathops` to be used with `ops` 3. As long as `pathops` itself supports Python 3.8, it should be compatible with `ops` 2. There are no planned changes in `ops` 3 that would break compatibility with `pathops`.