### PR TITLE
ci: skip the tests step cleanly if no packages are collected

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,7 @@ jobs:
 
   tests:
     needs: get-packages
+    if: ${{ fromJson(needs.get-packages.outputs.packages) }}
     strategy:
       matrix:
         package: ${{ fromJson(needs.get-packages.outputs.packages) }}


### PR DESCRIPTION
This PR is a quick fix for #54 to cleanly skip the test step if no packages are collected. Currently these are skipped with an error due to the matrix being empty, while this will have them properly be marked as skipped.