### PR TITLE
ci: correct test for an empty array

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
 
   tests:
     needs: get-packages
-    if: ${{ fromJson(needs.get-packages.outputs.packages) }}
+    if: ${{ needs.get-packages.outputs.packages != '[]' }}
     strategy:
       matrix:
         package: ${{ fromJson(needs.get-packages.outputs.packages) }}


### PR DESCRIPTION
This PR is a quick fix for #69 to correctly test for an empty array.