### PR TITLE
docs: simplify docs makefile and use just for docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,6 +29,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
       #- name: Spelling
       #  id: spellcheck-step
       #  if: success() || failure()

--- a/_docs/.readthedocs.yaml
+++ b/_docs/.readthedocs.yaml
@@ -7,20 +7,16 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.12"
   jobs:
+    create_environment:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
     pre_install:
-    - git fetch --unshallow || true
-
-# Build documentation in the docs/ directory with Sphinx
-sphinx:
-  builder: dirhtml
-  configuration: _docs/conf.py
-  fail_on_warning: true
-
-# Optionally declare the Python requirements required to build your docs
-python:
-  install:
-  - requirements: _docs/.sphinx/requirements.txt
+      - git fetch --unshallow || true
+    build:
+      html:
+        - uvx --from=rust-just just docs html

--- a/_docs/Makefile
+++ b/_docs/Makefile
@@ -1,4 +1,9 @@
-# Put it first so that "make" without argument is like "make help".
+# This Makefile was adapted from the documentation starter pack. We've kept it for
+# consistency with other Canonical projects, so that contributors can use familiar
+# `make` commands to build the docs.
+
+# To modify the doc build process, edit `docs.just` in the repo root.
+
 help:
 	@echo "\n" \
         "------------------------------------------------------------- \n" \

--- a/_docs/Makefile
+++ b/_docs/Makefile
@@ -1,179 +1,26 @@
-# Minimal makefile for Sphinx documentation
-#
-# Add your customisation to `Makefile` instead.
-
-# You can set these variables from the command line, and also
-# from the environment for the first two.
-SPHINXDIR       = .sphinx
-SPHINXOPTS      ?= -c . -d $(SPHINXDIR)/.doctrees -j auto
-SPHINXBUILD     ?= $(VENVDIR)/bin/sphinx-build
-SOURCEDIR       = .
-BUILDDIR        = _build
-VENVDIR         = $(SPHINXDIR)/venv
-PA11Y           = $(SPHINXDIR)/node_modules/pa11y/bin/pa11y.js --config $(SPHINXDIR)/pa11y.json
-VENV         	   = $(VENVDIR)/bin/activate
-TARGET          = *
-ALLFILES        =  *.rst **/*.rst
-METRICSDIR      = $(SOURCEDIR)/.sphinx/metrics
-REQPDFPACKS     = latexmk fonts-freefont-otf texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-font-utils texlive-lang-cjk texlive-xetex plantuml xindy tex-gyre dvipng
-CONFIRM_SUDO    ?= N
-VALE_CONFIG     = $(SPHINXDIR)/vale.ini
-
 # Put it first so that "make" without argument is like "make help".
 help:
 	@echo "\n" \
         "------------------------------------------------------------- \n" \
         "* watch, build and serve the documentation:  make run \n" \
         "* only build:                                make html \n" \
-        "* only serve:                                make serve \n" \
-        "* clean built doc files:                     make clean-doc \n" \
-        "* clean full environment:                    make clean \n" \
         "* check links:                               make linkcheck \n" \
-        "* check spelling:                            make spelling \n" \
-        "* check spelling (without building again):   make spellcheck \n" \
-        "* check inclusive language:                  make woke \n" \
-        "* check accessibility:                       make pa11y \n" \
-        "* check style guide compliance:              make vale \n" \
-        "* check style guide compliance on target:    make vale TARGET=* \n" \
-        "* check metrics for documentation:           make allmetrics \n" \
-        "* other possible targets:                    make <TAB twice> \n" \
+        "* clean full environment:                    make clean \n" \
         "------------------------------------------------------------- \n"
 
-.PHONY: full-help woke-install spellcheck-install pa11y-install install run html \
-        epub serve clean clean-doc spelling spellcheck linkcheck woke \
-        allmetrics pa11y pdf-prep-force pdf-prep pdf Makefile.sp vale-install vale
+.PHONY: html run clean install linkcheck
 
-full-help: $(VENVDIR)
-	@. $(VENV); $(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-	@echo "\n\033[1;31mNOTE: This help texts shows unsupported targets!\033[0m"
-	@echo "Run 'make help' to see supported targets."
+run:
+	uvx --from=rust-just just docs run
 
-# If requirements are updated, venv should be rebuilt and timestamped.
-$(VENVDIR):
-	python3 -c "import venv" || \
-        (echo "You must install python3-venv before you can build the documentation."; exit 1)
-	@echo "... setting up virtualenv"
-	python3 -m venv $(VENVDIR)
-	. $(VENV); pip install $(PIPOPTS) --require-virtualenv \
-	    --upgrade -r $(SPHINXDIR)/requirements.txt \
-            --log $(VENVDIR)/pip_install.log
-	@test ! -f $(VENVDIR)/pip_list.txt || \
-            mv $(VENVDIR)/pip_list.txt $(VENVDIR)/pip_list.txt.bak
-	@. $(VENV); pip list --local --format=freeze > $(VENVDIR)/pip_list.txt
-	@touch $(VENVDIR)
+html:
+	uvx --from=rust-just just docs html
 
-spellcheck-install:
-	@type aspell >/dev/null 2>&1 || \
-	{ \
-		echo "Installing system-wide \"aspell\" packages..."; \
-		confirm_sudo=$(CONFIRM_SUDO); \
-		if [ "$$confirm_sudo" != "y" ] && [ "$$confirm_sudo" != "Y" ]; then \
-			read -p "This requires sudo privileges. Proceed? [y/N]: " confirm_sudo; \
-		fi; \
-		if [ "$$confirm_sudo" = "y" ] || [ "$$confirm_sudo" = "Y" ]; then \
-			sudo apt-get install aspell aspell-en; \
-		else \
-			echo "Installation cancelled."; \
-		fi \
-	}
+linkcheck:
+	uvx --from=rust-just just docs linkcheck
 
-pa11y-install:
-	@type $(PA11Y) >/dev/null 2>&1 || { \
-			echo "Installing \"pa11y\" from npm... \n"; \
-			mkdir -p $(SPHINXDIR)/node_modules/ ; \
-			npm install --prefix $(SPHINXDIR) pa11y; \
-		}
+spellcheck:
+	uvx --from=rust-just just docs spellcheck
 
-install: $(VENVDIR)
-
-run: install
-	. $(VENV); $(VENVDIR)/bin/sphinx-autobuild -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
-
-# Doesn't depend on $(BUILDDIR) to rebuild properly at every run.
-html: install
-	. $(VENV); $(SPHINXBUILD) -W --keep-going -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" -w $(SPHINXDIR)/warnings.txt $(SPHINXOPTS)
-
-epub: install
-	. $(VENV); $(SPHINXBUILD) -b epub "$(SOURCEDIR)" "$(BUILDDIR)" -w $(SPHINXDIR)/warnings.txt $(SPHINXOPTS)
-
-serve: html
-	cd "$(BUILDDIR)"; python3 -m http.server --bind 127.0.0.1 8000
-
-clean: clean-doc
-	@test ! -e "$(VENVDIR)" -o -d "$(VENVDIR)" -a "$(abspath $(VENVDIR))" != "$(VENVDIR)"
-	rm -rf $(VENVDIR)
-	rm -rf $(SPHINXDIR)/node_modules/
-	rm -rf $(SPHINXDIR)/styles
-	rm -rf $(VALE_CONFIG)
-
-clean-doc:
-	git clean -fx "$(BUILDDIR)"
-	rm -rf $(SPHINXDIR)/.doctrees
-
-spellcheck: spellcheck-install
-	. $(VENV) ; python3 -m pyspelling -c $(SPHINXDIR)/spellingcheck.yaml -j $(shell nproc)
-
-spelling: html spellcheck
-
-linkcheck: install
-	. $(VENV) ; $(SPHINXBUILD) -b linkcheck "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) || { grep --color -F "[broken]" "$(BUILDDIR)/output.txt"; exit 1; }
-	exit 0
-
-pa11y: pa11y-install html
-	find $(BUILDDIR) -name *.html -print0 | xargs -n 1 -0 $(PA11Y)
-
-vale-install: install
-	@. $(VENV); test -d $(SPHINXDIR)/venv/lib/python*/site-packages/vale || pip install rst2html vale
-	@. $(VENV); test -f $(VALE_CONFIG) || python3 $(SPHINXDIR)/get_vale_conf.py
-	@printf '.Name=="Canonical.400-Enforce-inclusive-terms"' > $(SPHINXDIR)/styles/woke.filter
-	@printf '.Level=="error"' > $(SPHINXDIR)/styles/error.filter
-	@. $(VENV); find $(SPHINXDIR)/venv/lib/python*/site-packages/vale/vale_bin -size 195c -exec vale --config "$(VALE_CONFIG)" $(TARGET) > /dev/null \;
-
-woke: vale-install
-	@cat $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt > $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept_backup.txt
-	@cat $(SPHINXDIR)/.wordlist.txt $(SOURCEDIR)/.custom_wordlist.txt >> $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt
-	@printf "Running Vale acceptable term check against $(TARGET). To change target set TARGET= with make command\n"
-	@. $(VENV); vale --config="$(VALE_CONFIG)" --filter='$(SPHINXDIR)/styles/woke.filter' --glob='*.{md,rst}' $(TARGET) || true
-	@cat $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept_backup.txt > $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt && rm $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept_backup.txt
-
-vale: vale-install
-	@cat $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt > $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept_backup.txt
-	@cat $(SPHINXDIR)/.wordlist.txt $(SOURCEDIR)/.custom_wordlist.txt >> $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt
-	@printf "Running Vale against $(TARGET). To change target set TARGET= with make command\n"
-	@. $(VENV); vale --config="$(VALE_CONFIG)" --filter='$(SPHINXDIR)/styles/error.filter' --glob='*.{md,rst}' $(TARGET) || true
-	@cat $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept_backup.txt > $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept.txt && rm $(SPHINXDIR)/styles/config/vocabularies/Canonical/accept_backup.txt
-
-pdf-prep: install
-	@for packageName in $(REQPDFPACKS); do (dpkg-query -W -f='$${Status}' $$packageName 2>/dev/null | \
-        grep -c "ok installed" >/dev/null && echo "Package $$packageName is installed") && continue || \
-        (echo "\nPDF generation requires the installation of the following packages: $(REQPDFPACKS)" && \
-        echo "" && echo "Run 'sudo make pdf-prep-force' to install these packages" && echo "" && echo \
-        "Please be aware these packages will be installed to your system") && exit 1 ; done
-
-pdf-prep-force:
-	apt-get update
-	apt-get upgrade -y
-	apt-get install --no-install-recommends -y $(REQPDFPACKS) \
-
-pdf: pdf-prep
-	@. $(VENV); sphinx-build -M latexpdf "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
-	@rm ./$(BUILDDIR)/latex/front-page-light.pdf || true
-	@rm ./$(BUILDDIR)/latex/normal-page-footer.pdf || true
-	@find ./$(BUILDDIR)/latex -name "*.pdf" -exec mv -t ./$(BUILDDIR) {} +
-	@rm -r $(BUILDDIR)/latex
-	@echo "\nOutput can be found in ./$(BUILDDIR)\n"
-
-allmetrics: html
-	@echo "Recording documentation metrics..."
-	@echo "Checking for existence of vale..."
-	. $(VENV)
-	@. $(VENV); test -d $(SPHINXDIR)/venv/lib/python*/site-packages/vale || pip install vale
-	@. $(VENV); test -f $(VALE_CONFIG) || python3 $(SPHINXDIR)/get_vale_conf.py
-	@. $(VENV); find $(SPHINXDIR)/venv/lib/python*/site-packages/vale/vale_bin -size 195c -exec vale --config "$(VALE_CONFIG)" $(TARGET) > /dev/null \;
-	@eval '$(METRICSDIR)/source_metrics.sh $(PWD)'
-	@eval '$(METRICSDIR)/build_metrics.sh $(PWD) $(METRICSDIR)'
-
-# Catch-all target: route all unknown targets to Sphinx using the new
-# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%:
-	. $(VENV); $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+clean:
+	uvx --from=rust-just just docs clean

--- a/_docs/Makefile
+++ b/_docs/Makefile
@@ -4,8 +4,9 @@ help:
         "------------------------------------------------------------- \n" \
         "* watch, build and serve the documentation:  make run \n" \
         "* only build:                                make html \n" \
-        "* check links:                               make linkcheck \n" \
         "* clean full environment:                    make clean \n" \
+        "* check links:                               make linkcheck \n" \
+        "* check spelling (without building again):   make spellcheck \n" \
         "------------------------------------------------------------- \n"
 
 .PHONY: html run clean install linkcheck
@@ -16,11 +17,11 @@ run:
 html:
 	uvx --from=rust-just just docs html
 
+clean:
+	uvx --from=rust-just just docs clean
+
 linkcheck:
 	uvx --from=rust-just just docs linkcheck
 
 spellcheck:
 	uvx --from=rust-just just docs spellcheck
-
-clean:
-	uvx --from=rust-just just docs clean

--- a/_docs/Makefile
+++ b/_docs/Makefile
@@ -11,7 +11,7 @@ help:
         "* only build:                                make html \n" \
         "* clean full environment:                    make clean \n" \
         "* check links:                               make linkcheck \n" \
-        "* check spelling (without building again):   make spellcheck \n" \
+        "* check spelling:                            make spelling \n" \
         "------------------------------------------------------------- \n"
 
 .PHONY: html run clean install linkcheck
@@ -28,5 +28,5 @@ clean:
 linkcheck:
 	uvx --from=rust-just just docs linkcheck
 
-spellcheck:
-	uvx --from=rust-just just docs spellcheck
+spelling:
+	uvx --from=rust-just just docs spelling

--- a/docs.just
+++ b/docs.just
@@ -1,0 +1,34 @@
+_docs_build_location := env('READTHEDOCS_OUTPUT', '_build')
+
+[doc('Build the docs.')]
+[working-directory: '_docs']
+html:
+    uvx --with-requirements=.sphinx/requirements.txt --from=sphinx \
+        sphinx-build -T -W --keep-going -b dirhtml -d _build/doctrees -D language=en . '{{_docs_build_location}}/html'
+
+[doc('Watch, build, and serve the docs.')]
+[working-directory: '_docs']
+run:
+    uvx --with-requirements=.sphinx/requirements.txt --from=sphinx \
+        sphinx-autobuild --watch .. --ignore '**/generated/*' -b dirhtml . '{{_docs_build_location}}/html'
+
+[doc('Check links.')]
+[working-directory: '_docs']
+linkcheck:
+    uvx --with-requirements=.sphinx/requirements.txt --from=sphinx \
+        sphinx-build -b linkcheck . '{{_docs_build_location}}'
+
+[doc('Check spelling.')]
+[working-directory: '_docs']
+spellcheck:
+    uvx pyspelling -c .sphinx/spellingcheck.yaml -j $(nproc)
+
+[doc('Remove files created by building the docs.')]
+[working-directory: '_docs']
+clean:
+    git clean -fx '{{_docs_build_location}}'
+    rm -rf .sphinx/.doctrees
+    rm -rf .sphinx/node_modules/
+    rm -rf .sphinx/styles
+    rm -rf .sphinx/vale.ini
+    rm -rf reference/generated

--- a/docs.just
+++ b/docs.just
@@ -18,7 +18,7 @@ linkcheck:
         sphinx-build -b linkcheck . '{{build_dir}}'
 
 [doc('Check spelling.')]
-spellcheck:
+spelling: html
     uvx pyspelling -c .sphinx/spellingcheck.yaml -j $(nproc)
 
 [doc('Remove files created by building the docs.')]

--- a/docs.just
+++ b/docs.just
@@ -1,20 +1,21 @@
 set working-directory := '_docs'
-_docs_build_location := env('READTHEDOCS_OUTPUT', '_build')
+
+build_dir := env('READTHEDOCS_OUTPUT', '_build')
 
 [doc('Build the docs.')]
 html:
     uvx --with-requirements=.sphinx/requirements.txt --from=sphinx \
-        sphinx-build -T -W --keep-going -b dirhtml -d _build/doctrees -D language=en . '{{_docs_build_location}}/html'
+        sphinx-build -T -W --keep-going -b dirhtml -d _build/doctrees -D language=en . '{{build_dir}}/html'
 
 [doc('Watch, build, and serve the docs.')]
 run:
     uvx --with-requirements=.sphinx/requirements.txt --from=sphinx \
-        sphinx-autobuild --watch .. --ignore '**/generated/*' -b dirhtml . '{{_docs_build_location}}/html'
+        sphinx-autobuild --watch .. --ignore '**/generated/*' -b dirhtml . '{{build_dir}}/html'
 
 [doc('Check links.')]
 linkcheck:
     uvx --with-requirements=.sphinx/requirements.txt --from=sphinx \
-        sphinx-build -b linkcheck . '{{_docs_build_location}}'
+        sphinx-build -b linkcheck . '{{build_dir}}'
 
 [doc('Check spelling.')]
 spellcheck:
@@ -22,7 +23,7 @@ spellcheck:
 
 [doc('Remove files created by building the docs.')]
 clean:
-    git clean -fx '{{_docs_build_location}}'
+    git clean -fx '{{build_dir}}'
     rm -rf .sphinx/.doctrees
     rm -rf .sphinx/node_modules/
     rm -rf .sphinx/styles

--- a/docs.just
+++ b/docs.just
@@ -1,30 +1,26 @@
+set working-directory := '_docs'
 _docs_build_location := env('READTHEDOCS_OUTPUT', '_build')
 
 [doc('Build the docs.')]
-[working-directory: '_docs']
 html:
     uvx --with-requirements=.sphinx/requirements.txt --from=sphinx \
         sphinx-build -T -W --keep-going -b dirhtml -d _build/doctrees -D language=en . '{{_docs_build_location}}/html'
 
 [doc('Watch, build, and serve the docs.')]
-[working-directory: '_docs']
 run:
     uvx --with-requirements=.sphinx/requirements.txt --from=sphinx \
         sphinx-autobuild --watch .. --ignore '**/generated/*' -b dirhtml . '{{_docs_build_location}}/html'
 
 [doc('Check links.')]
-[working-directory: '_docs']
 linkcheck:
     uvx --with-requirements=.sphinx/requirements.txt --from=sphinx \
         sphinx-build -b linkcheck . '{{_docs_build_location}}'
 
 [doc('Check spelling.')]
-[working-directory: '_docs']
 spellcheck:
     uvx pyspelling -c .sphinx/spellingcheck.yaml -j $(nproc)
 
 [doc('Remove files created by building the docs.')]
-[working-directory: '_docs']
 clean:
     git clean -fx '{{_docs_build_location}}'
     rm -rf .sphinx/.doctrees

--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+mod docs  # load mod.just to expose docs subcommands
+
 set ignore-comments  # don't print comment lines in recipes
 
 # set on the commandline as needed, e.g. `just package=pathops python=3.8 unit`
@@ -7,7 +9,7 @@ python := '3.12'
 [doc('Describe usage and list the available recipes.')]
 _help:
     @echo 'All recipes require {{CYAN}}`uv`{{NORMAL}} to be available.'
-    @just --list --unsorted
+    @just --list --unsorted --list-submodules
 
 [doc('Run `ruff` and `codespell`, failing afterwards if any errors are found.')]
 lint:

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-mod docs  # load mod.just to expose docs subcommands
+mod docs  # load docs module to expose docs subcommands
 
 set ignore-comments  # don't print comment lines in recipes
 


### PR DESCRIPTION
This PR refactors the docs CI to use `uv` to run the `sphinx` commands, and use the same command to build the docs in readthedocs as is used locally.

I've also taken the opportunity to move the commands to a `justfile` for cleaner syntax and the ability to run the docs build commands from anywhere in the repository. They're all in a separate module, `docs.just`, keeping things clean and separate. This allows the default docs build (`html`, used in readthedocs) to be run with `just docs`, while other commands can be run with (e.g.) `just docs linkcheck`.

The main `_docs/Makefile` targets are preserved for compatibility with the Canonical docs workflows, and to allow contributors who are used to this format to easily find and run the docs commands. These targets run `just`, making the `docs.just` file the single source of truth in all cases.