### PR TITLE
docs: change title of how-to category

### DIFF
--- a/_docs/how-to/index.md
+++ b/_docs/how-to/index.md
@@ -1,4 +1,4 @@
-# How To
+# How-to guides
 
 ```{toctree}
 :maxdepth: 1


### PR DESCRIPTION
I just noticed that the title of the how-to category should be "How-to guides" rather than "How To".